### PR TITLE
[1] API 타입 정의 1

### DIFF
--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -1,23 +1,23 @@
 import { UserType } from '~/types/common';
 
-export interface loginRequestType {
+export interface LoginRequestType {
   email: string;
   password: string;
 }
 
-export interface loginResponseType {
+export interface LoginResponseType {
   user: UserType;
   token: string;
 }
 
-export interface signupRequestType {
+export interface SignupRequestType {
   email: string;
   fullName: string;
   password: string;
 }
-export interface signupResponseType {
+export interface SignupResponseType {
   user: UserType;
   token: string;
 }
 
-export type authUserResponseType = UserType;
+export type AuthUserResponseType = UserType;

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -1,0 +1,23 @@
+import { UserType } from '~/types/common';
+
+export interface loginRequestType {
+  email: string;
+  password: string;
+}
+
+export interface loginResponseType {
+  user: UserType;
+  token: string;
+}
+
+export interface signupRequestType {
+  email: string;
+  fullName: string;
+  password: string;
+}
+export interface signupResponseType {
+  user: UserType;
+  token: string;
+}
+
+export type authUserResponseType = UserType;

--- a/src/types/api/channels.ts
+++ b/src/types/api/channels.ts
@@ -1,0 +1,5 @@
+import { ChannelType } from '~/types/common';
+
+export type getChannelsResponseType = ChannelType[];
+
+export type getChannelInfoResponseType = ChannelType;

--- a/src/types/api/channels.ts
+++ b/src/types/api/channels.ts
@@ -1,5 +1,5 @@
 import { ChannelType } from '~/types/common';
 
-export type getChannelsResponseType = ChannelType[];
+export type GetChannelsResponseType = ChannelType[];
 
-export type getChannelInfoResponseType = ChannelType;
+export type GetChannelInfoResponseType = ChannelType;

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -1,0 +1,6 @@
+// api 타이핑에서 공통적으로 사용되는 구조를 재사용하기 위해 정의한 파일입니다
+
+export interface rangeTemplateType {
+  offset?: number;
+  limit?: number;
+}

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -1,6 +1,6 @@
 // api 타이핑에서 공통적으로 사용되는 구조를 재사용하기 위해 정의한 파일입니다
 
-export interface rangeTemplateType {
+export interface RangeTemplateType {
   offset?: number;
   limit?: number;
 }

--- a/src/types/api/likes.ts
+++ b/src/types/api/likes.ts
@@ -1,0 +1,11 @@
+import { LikeType } from '~/types/common';
+
+export interface createLikeRequestType {
+  postId: string;
+}
+export type createLikeResponseType = LikeType;
+
+export interface deleteLikeRequestType {
+  id: string;
+}
+export type deleteLikeResponseType = LikeType;

--- a/src/types/api/likes.ts
+++ b/src/types/api/likes.ts
@@ -1,11 +1,11 @@
 import { LikeType } from '~/types/common';
 
-export interface createLikeRequestType {
+export interface CreateLikeRequestType {
   postId: string;
 }
-export type createLikeResponseType = LikeType;
+export type CreateLikeResponseType = LikeType;
 
-export interface deleteLikeRequestType {
+export interface DeleteLikeRequestType {
   id: string;
 }
-export type deleteLikeResponseType = LikeType;
+export type DeleteLikeResponseType = LikeType;

--- a/src/types/api/posts.ts
+++ b/src/types/api/posts.ts
@@ -1,0 +1,19 @@
+import { PostType } from '~/types/common';
+import { rangeTemplateType } from './common';
+
+export interface getChannelPostsRequestType extends rangeTemplateType {}
+export type getChannelPostsResponseType = PostType[];
+
+export interface getUserPostsRequestType extends rangeTemplateType {}
+export type getUserPostsResponseType = PostType[];
+
+export type createPostRequestType = FormData;
+
+export type getPostDetailResponseType = PostType;
+
+export type updatePostRequestType = FormData;
+export type updatePostResponseType = PostType;
+
+export interface deletePostRequestType {
+  id: string;
+}

--- a/src/types/api/posts.ts
+++ b/src/types/api/posts.ts
@@ -1,19 +1,19 @@
 import { PostType } from '~/types/common';
-import { rangeTemplateType } from './common';
+import { RangeTemplateType } from './common';
 
-export interface getChannelPostsRequestType extends rangeTemplateType {}
-export type getChannelPostsResponseType = PostType[];
+export interface GetChannelPostsRequestType extends RangeTemplateType {}
+export type GetChannelPostsResponseType = PostType[];
 
-export interface getUserPostsRequestType extends rangeTemplateType {}
-export type getUserPostsResponseType = PostType[];
+export interface GetUserPostsRequestType extends RangeTemplateType {}
+export type GetUserPostsResponseType = PostType[];
 
-export type createPostRequestType = FormData;
+export type CreatePostRequestType = FormData;
 
-export type getPostDetailResponseType = PostType;
+export type GetPostDetailResponseType = PostType;
 
-export type updatePostRequestType = FormData;
-export type updatePostResponseType = PostType;
+export type UpdatePostRequestType = FormData;
+export type UpdatePostResponseType = PostType;
 
-export interface deletePostRequestType {
+export interface DeletePostRequestType {
   id: string;
 }

--- a/src/types/api/settings.ts
+++ b/src/types/api/settings.ts
@@ -1,11 +1,11 @@
 import { UserType } from '~/types/common';
 
-export interface updateUserRequestType {
+export interface UpdateUserRequestType {
   fullName: string;
   username: string;
 }
-export type updateUserResponseType = UserType;
+export type UpdateUserResponseType = UserType;
 
-export interface updatePasswordRequestType {
+export interface UpdatePasswordRequestType {
   password: string;
 }

--- a/src/types/api/settings.ts
+++ b/src/types/api/settings.ts
@@ -1,0 +1,11 @@
+import { UserType } from '~/types/common';
+
+export interface updateUserRequestType {
+  fullName: string;
+  username: string;
+}
+export type updateUserResponseType = UserType;
+
+export interface updatePasswordRequestType {
+  password: string;
+}

--- a/src/types/api/users.ts
+++ b/src/types/api/users.ts
@@ -1,12 +1,12 @@
 import { UserType } from '~/types/common';
-import { rangeTemplateType } from './common';
+import { RangeTemplateType } from './common';
 
-export interface getUsersRequestType extends rangeTemplateType {}
-export type getUsersResponseType = UserType[];
+export interface GetUsersRequestType extends RangeTemplateType {}
+export type GetUsersResponseType = UserType[];
 
-export type onlineUsersResponseType = UserType[];
+export type OnlineUsersResponseType = UserType[];
 
-export type getUserResponseType = UserType;
+export type GetUserResponseType = UserType;
 
-export type uploadPhotoRequestType = FormData;
-export type uploadPhotoResponseType = UserType;
+export type UploadPhotoRequestType = FormData;
+export type UploadPhotoResponseType = UserType;

--- a/src/types/api/users.ts
+++ b/src/types/api/users.ts
@@ -1,0 +1,12 @@
+import { UserType } from '~/types/common';
+import { rangeTemplateType } from './common';
+
+export interface getUsersRequestType extends rangeTemplateType {}
+export type getUsersResponseType = UserType[];
+
+export type onlineUsersResponseType = UserType[];
+
+export type getUserResponseType = UserType;
+
+export type uploadPhotoRequestType = FormData;
+export type uploadPhotoResponseType = UserType;


### PR DESCRIPTION
## :rocket: 주요 작업 내용
아래 도메인의 api들에 대한 타이핑을 작성했습니다
- login
- signup
- logout
- auth-user
- users
- settings
- channels
- posts
- likes

작성 과정에서 api 타입들에서 공통으로 사용되는 구조를 재사용하기 위해 `~/types/api/common.ts`파일을 생성했습니다
## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/88219703/7b48ef06-8448-4d36-9218-0e3695326557)

## :white_check_mark: 고민 중인 부분 및 참고사항
- [ ] 네이밍 컨벤션이 적절한가요?
- [ ] 폴더 분리 및 타입 정의가 적절한가요? 

close #1 