### PR TITLE
[28] stylelint `declaration-block-no-redundant-longhand-properties` 규칙 비활성화

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -6,6 +6,6 @@ export default {
     'declaration-property-value-disallowed-list': {
       '/.+/': '/(rgba?|hsla?)(.*)/',
     },
-    'declaration-block-no-redundant-longhand-properties': false,
+    'declaration-block-no-redundant-longhand-properties': null,
   },
 };

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -6,5 +6,6 @@ export default {
     'declaration-property-value-disallowed-list': {
       '/.+/': '/(rgba?|hsla?)(.*)/',
     },
+    'declaration-block-no-redundant-longhand-properties': false,
   },
 };


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- stylelint `declaration-block-no-redundant-longhand-properties` 규칙 비활성화

## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86952779/b52846ab-b29e-4761-9f79-d01cb810bab2)

close #28 
