### PR TITLE
[44] stylelint `custom-property-pattern` 규칙 비활성화

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -7,5 +7,6 @@ export default {
       '/.+/': '/(rgba?|hsla?)(.*)/',
     },
     'declaration-block-no-redundant-longhand-properties': null,
+    'custom-property-pattern': null,
   },
 };


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- stylelint `custom-property-pattern` 규칙 비활성화

## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86952779/f74ea8a4-afdb-4a26-bf9e-8d36ca12a8a6)
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86952779/dbfd14f4-23f9-40fa-adfd-ab1fe0a46bde)

close #44 
