### PR TITLE
[36] Radio Button 컴포넌트 구현

### DIFF
--- a/src/colors.css
+++ b/src/colors.css
@@ -83,8 +83,6 @@
   --blue900: rgb(0, 69, 143);
   --blue950: rgb(13, 25, 95);
 
-  --radioGray: #59626b;
-
   --primaryColor: rgb(254, 147, 56);
   --secondaryColor: var(--blue500);
 

--- a/src/colors.css
+++ b/src/colors.css
@@ -83,6 +83,8 @@
   --blue900: rgb(0, 69, 143);
   --blue950: rgb(13, 25, 95);
 
+  --radioGray: #59626b;
+
   --primaryColor: rgb(254, 147, 56);
   --secondaryColor: var(--blue500);
 }

--- a/src/components/RadioGroup/Radio.tsx
+++ b/src/components/RadioGroup/Radio.tsx
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
+import Flex from '~/components/common/Flex';
+import Text from '~/components/common/Text';
 
 export interface RadioPropsType {
   children?: string;
@@ -7,6 +9,7 @@ export interface RadioPropsType {
   defaultChecked?: boolean;
   disabled?: boolean;
   checked?: boolean;
+  onChange: () => void;
 }
 
 const RadioButtonInput = styled.input`
@@ -18,10 +21,10 @@ const RadioButtonInput = styled.input`
   width: 2.5rem;
   height: 2.5rem;
   outline: none;
-  border: 3px solid var(--radioGray);
+  border: 3px solid var(--adaptive500);
   border-radius: 50%;
 
-  color: var(--radioGray);
+  color: var(--adaptive500);
 
   appearance: none;
 
@@ -53,9 +56,15 @@ const Radio = ({
   defaultChecked,
   disabled,
   checked,
+  onChange,
 }: RadioPropsType) => {
   return (
-    <label>
+    <Flex
+      as='fieldset'
+      direction='column'
+      alignItems='center'
+      gap={1}
+    >
       <RadioButtonInput
         type='radio'
         value={value}
@@ -63,9 +72,10 @@ const Radio = ({
         defaultChecked={defaultChecked}
         disabled={disabled}
         checked={checked}
+        onChange={onChange}
       ></RadioButtonInput>
-      {children}
-    </label>
+      <Text as='label'>{children}</Text>
+    </Flex>
   );
 };
 

--- a/src/components/RadioGroup/Radio.tsx
+++ b/src/components/RadioGroup/Radio.tsx
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+
+export interface RadioPropsType {
+  children?: string;
+  value: string;
+  name: string;
+  defaultChecked?: boolean;
+  disabled?: boolean;
+  checked?: boolean;
+}
+
+const RadioButtonInput = styled.input`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+
+  width: 2.5rem;
+  height: 2.5rem;
+  outline: none;
+  border: 3px solid var(--radioGray);
+  border-radius: 50%;
+
+  color: var(--radioGray);
+
+  appearance: none;
+
+  cursor: pointer;
+
+  &:checked {
+    border: 4px solid var(--primaryColor);
+    color: var(--primaryColor);
+
+    &::after {
+      display: block;
+      position: absolute;
+
+      width: 1.24rem;
+      height: 1.24rem;
+      border-radius: 50%;
+
+      background-color: var(--primaryColor);
+
+      content: '';
+    }
+  }
+`;
+
+const Radio = ({
+  children,
+  value,
+  name,
+  defaultChecked,
+  disabled,
+  checked,
+}: RadioPropsType) => {
+  return (
+    <label>
+      <RadioButtonInput
+        type='radio'
+        value={value}
+        name={name}
+        defaultChecked={defaultChecked}
+        disabled={disabled}
+        checked={checked}
+      ></RadioButtonInput>
+      {children}
+    </label>
+  );
+};
+
+export default Radio;

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,34 @@
+import { ReactNode } from 'react';
+import Container from '~/components/common/Container';
+import Flex from '~/components/common/Flex';
+import Text from '~/components/common/Text';
+
+export interface RadioGroupPropsType {
+  labels?: string[];
+  children: ReactNode;
+}
+
+function RadioGroup({ labels, children }: RadioGroupPropsType) {
+  return (
+    <Container maxWidth='sm'>
+      <Flex
+        direction='column'
+        justifyContent='space-between'
+        style={{ width: '33rem', height: '4.5rem' }}
+      >
+        <Flex
+          justifyContent='space-between'
+          alignItems='center'
+          style={{ padding: '0  0.25rem' }}
+        >
+          {children}
+        </Flex>
+        <Flex justifyContent='space-between'>
+          {labels ? labels.map((label) => <Text>{label}</Text>) : ''}
+        </Flex>
+      </Flex>
+    </Container>
+  );
+}
+
+export default RadioGroup;

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,34 +1,54 @@
-import { ReactNode } from 'react';
+import React, { useState } from 'react';
 import Container from '~/components/common/Container';
 import Flex from '~/components/common/Flex';
-import Text from '~/components/common/Text';
+import Radio from './Radio';
 
 export interface RadioGroupPropsType {
-  labels?: string[];
-  children: ReactNode;
+  options: { label: string; value: string }[];
+  defaultValue?: string;
+  disabled?: boolean;
+  onChange?: (value: string) => void;
 }
 
-function RadioGroup({ labels, children }: RadioGroupPropsType) {
+const RadioGroup: React.FC<RadioGroupPropsType> = ({
+  options,
+  defaultValue,
+  disabled,
+  onChange,
+}) => {
+  const [selectedValue, setSelectedValue] = useState<string | undefined>(
+    defaultValue
+  );
+
+  const handleRadioChange = (value: string) => {
+    setSelectedValue(value);
+    if (onChange) {
+      onChange(value);
+    }
+  };
+
   return (
     <Container maxWidth='sm'>
       <Flex
-        direction='column'
         justifyContent='space-between'
-        style={{ width: '33rem', height: '4.5rem' }}
+        alignItems='flex-start'
+        style={{ padding: '0  0.25rem' }}
       >
-        <Flex
-          justifyContent='space-between'
-          alignItems='center'
-          style={{ padding: '0  0.25rem' }}
-        >
-          {children}
-        </Flex>
-        <Flex justifyContent='space-between'>
-          {labels ? labels.map((label) => <Text>{label}</Text>) : ''}
-        </Flex>
+        {options.map((option) => (
+          <Radio
+            key={option.value}
+            value={option.value}
+            name='radioGroup'
+            checked={selectedValue === option.value}
+            disabled={disabled}
+            onChange={() => handleRadioChange(option.value)}
+          >
+            {option.label}
+          </Radio>
+        ))}
       </Flex>
     </Container>
   );
-}
+};
 
 export default RadioGroup;

--- a/src/stories/components/Radio.stories.tsx
+++ b/src/stories/components/Radio.stories.tsx
@@ -1,0 +1,21 @@
+import Radio, { RadioPropsType } from '~/components/RadioGroup/Radio';
+
+export default {
+  title: 'Component/Radio',
+  component: Radio,
+  argTypes: {
+    value: { control: { type: 'string' } },
+    name: { control: { type: 'string' } },
+    checked: { control: { type: 'boolean' } },
+  },
+};
+
+export const Default = (args: RadioPropsType) => {
+  return <Radio {...args}></Radio>;
+};
+
+Default.args = {
+  value: '1',
+  name: 'toilet',
+  checked: true,
+};

--- a/src/stories/components/RadioGroup.stories.tsx
+++ b/src/stories/components/RadioGroup.stories.tsx
@@ -1,4 +1,3 @@
-// import Radio from '~/components/RadioGroup/Radio';
 import RadioGroup, {
   RadioGroupPropsType,
 } from '~/components/RadioGroup/RadioGroup';
@@ -7,14 +6,6 @@ export default {
   title: 'Component/RadioGroup',
   component: RadioGroup,
   argTypes: {
-    // labels: {
-    //   type: { name: 'array' },
-    //   description: 'label 문자열로 이루어진 배열',
-    //   control: {
-    //     type: 'array',
-    //     separator: ',',
-    //   },
-    // },
     options: {
       type: { name: 'array' },
       control: {

--- a/src/stories/components/RadioGroup.stories.tsx
+++ b/src/stories/components/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import Radio from '~/components/RadioGroup/Radio';
+// import Radio from '~/components/RadioGroup/Radio';
 import RadioGroup, {
   RadioGroupPropsType,
 } from '~/components/RadioGroup/RadioGroup';
@@ -7,12 +7,18 @@ export default {
   title: 'Component/RadioGroup',
   component: RadioGroup,
   argTypes: {
-    labels: {
+    // labels: {
+    //   type: { name: 'array' },
+    //   description: 'label 문자열로 이루어진 배열',
+    //   control: {
+    //     type: 'array',
+    //     separator: ',',
+    //   },
+    // },
+    options: {
       type: { name: 'array' },
-      description: 'label 문자열로 이루어진 배열',
       control: {
         type: 'array',
-        separator: ',',
       },
     },
   },
@@ -23,30 +29,11 @@ export const Default = (args: RadioGroupPropsType) => {
 };
 
 Default.args = {
-  children: (
-    <>
-      <Radio
-        name='toilet'
-        value='1'
-        defaultChecked
-      ></Radio>
-      <Radio
-        name='toilet'
-        value='2'
-      ></Radio>
-      <Radio
-        name='toilet'
-        value='3'
-      ></Radio>
-      <Radio
-        name='toilet'
-        value='4'
-      ></Radio>
-      <Radio
-        name='toilet'
-        value='5'
-      ></Radio>
-    </>
-  ),
-  labels: ['별로에요', '잘 모르겠어요', '쾌적했어요'],
+  options: [
+    { label: '별로에요', value: '1' },
+    { label: '', value: '2' },
+    { label: '잘 모르겠어요', value: '3' },
+    { label: '', value: '4' },
+    { label: '쾌적했어요', value: '5' },
+  ],
 };

--- a/src/stories/components/RadioGroup.stories.tsx
+++ b/src/stories/components/RadioGroup.stories.tsx
@@ -1,0 +1,52 @@
+import Radio from '~/components/RadioGroup/Radio';
+import RadioGroup, {
+  RadioGroupPropsType,
+} from '~/components/RadioGroup/RadioGroup';
+
+export default {
+  title: 'Component/RadioGroup',
+  component: RadioGroup,
+  argTypes: {
+    labels: {
+      type: { name: 'array' },
+      description: 'label 문자열로 이루어진 배열',
+      control: {
+        type: 'array',
+        separator: ',',
+      },
+    },
+  },
+};
+
+export const Default = (args: RadioGroupPropsType) => {
+  return <RadioGroup {...args}></RadioGroup>;
+};
+
+Default.args = {
+  children: (
+    <>
+      <Radio
+        name='toilet'
+        value='1'
+        defaultChecked
+      ></Radio>
+      <Radio
+        name='toilet'
+        value='2'
+      ></Radio>
+      <Radio
+        name='toilet'
+        value='3'
+      ></Radio>
+      <Radio
+        name='toilet'
+        value='4'
+      ></Radio>
+      <Radio
+        name='toilet'
+        value='5'
+      ></Radio>
+    </>
+  ),
+  labels: ['별로에요', '잘 모르겠어요', '쾌적했어요'],
+};


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- Radio Button 컴포넌트를 구현했습니다. 
- Container, Flex, Text 컴포넌트를 반영했습니다.
## :pushpin: 스크린샷
<img width="1077" alt="스크린샷 2024-01-04 오전 11 50 24" src="https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/62047243/bb34fb2a-e80f-4568-b573-5b40bf15101d">


## :white_check_mark: 고민 중인 부분 및 참고사항
- [ ] 각 RadioGroup마다 아래 적혀있는 label 내용이 다른데 현재는 해당 label을 props로 받아오게 구현했습니다. 방법이 적절한지 궁금합니다. 
- [ ] 기타 수정할 점을 알려주시면 감사하겠습니다. 
- [ ] Storybook에서 children에 대한 argTypes를 지정하는 것은 일반적으로 필요하지 않다고 해서 children에 대한 argTypes는 지정하지 않았습니다. 다른 의견이 있으신 분은 알려주세요!

### 개선 사항
- Radio 컴포넌트에서 직접 label을 출력하도록 변경
- Radio 컴포넌트, RadioGroup 컴포넌트의 props에 onClick 추가
- RadioGroup 컴포넌트의 props에 options 추가, options 기반으로 Radio 생성 (스토리북 참고바랍니다)
<!-- ## 이슈 번호 close -->
close #36 