### PR TITLE
[47] Avatar 컴포넌트 구현

### DIFF
--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -28,7 +28,7 @@ const Avatar = ({
 }: AvatarPropsType) => {
   return (
     <AvatarWrapper
-      size={AVATAR_SIZE[size]}
+      size={size}
       hoverColor={hoverColor}
       onClick={handleClick}
     >
@@ -49,16 +49,22 @@ const Avatar = ({
 
 export default Avatar;
 
-const AvatarWrapper = styled.div<{ size: string; hoverColor: ColorType }>`
+const AvatarWrapper = styled.div<{
+  size: AvatarSizeType;
+  hoverColor: ColorType;
+}>`
   overflow: hidden;
 
-  width: ${({ size }) => size};
-  height: ${({ size }) => size};
-  border: 0.125rem solid var(--adaptive600);
+  width: ${({ size }) => AVATAR_SIZE[size]};
+  height: ${({ size }) => AVATAR_SIZE[size]};
+  border: ${({ size }) =>
+    size === 'sm'
+      ? `0.125rem solid var(--adaptive600)`
+      : `0.25rem solid var(--adaptive600)`};
   border-radius: 50%;
 
   cursor: pointer;
-  transition: all 0.2s ease-out;
+  transition: border-color 0.2s ease-out;
 
   &:hover {
     border-color: ${({ hoverColor }) => `var(${hoverColor})`};

--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import Image, { ImageModeType } from './Image';
+import { AvatarSizeType } from '~/types/design/avatar';
+import { AVATAR_SIZE } from '~/constants/design';
+import ColorType from '~/types/design/color';
+
+export interface AvatarPropsType {
+  lazy?: boolean;
+  threshold?: number;
+  src?: string;
+  placeholder?: string;
+  alt?: string;
+  mode?: ImageModeType;
+  size: AvatarSizeType;
+  hoverColor?: ColorType;
+  handleClick: () => void;
+}
+const Avatar = ({
+  lazy = true,
+  threshold,
+  src,
+  placeholder,
+  alt = '프로필 바로가기',
+  mode,
+  size,
+  hoverColor = '--primaryColor',
+  handleClick,
+}: AvatarPropsType) => {
+  return (
+    <AvatarWrapper
+      size={AVATAR_SIZE[size]}
+      hoverColor={hoverColor}
+      onClick={handleClick}
+    >
+      <Image
+        block
+        lazy={lazy}
+        threshold={threshold}
+        src={src}
+        placeholder={placeholder}
+        alt={alt}
+        mode={mode}
+        width={AVATAR_SIZE[size]}
+        height={AVATAR_SIZE[size]}
+      />
+    </AvatarWrapper>
+  );
+};
+
+export default Avatar;
+
+const AvatarWrapper = styled.div<{ size: string; hoverColor: ColorType }>`
+  overflow: hidden;
+
+  width: ${({ size }) => size};
+  height: ${({ size }) => size};
+  border: 0.125rem solid var(--adaptive600);
+  border-radius: 50%;
+
+  cursor: pointer;
+  transition: all 0.2s ease-out;
+
+  &:hover {
+    border-color: ${({ hoverColor }) => `var(${hoverColor})`};
+  }
+`;

--- a/src/components/common/Image/index.tsx
+++ b/src/components/common/Image/index.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import useIntersectionObserver from '~/hooks/useIntersectionObserver';
 import ColorType from '~/types/design/color';
+import { handleSizeUnit } from '~/utils/handleSizeUnit';
 
 export type ImageModeType = 'cover' | 'contain' | 'fill';
 export interface ImagePropsType {
@@ -9,8 +10,8 @@ export interface ImagePropsType {
   placeholder?: string;
   src?: string;
   block?: boolean;
-  width: number;
-  height: number;
+  width: number | string;
+  height: number | string;
   alt: string;
   mode?: ImageModeType;
   letterBoxColor?: ColorType;
@@ -19,8 +20,8 @@ export interface ImagePropsType {
 interface ImageStylePropsType {
   block?: boolean;
   mode: ImageModeType;
-  width: number;
-  height: number;
+  width: string;
+  height: string;
 }
 const Image = ({
   lazy,
@@ -55,8 +56,8 @@ const Image = ({
       height={height}
     >
       <ImageStyled
-        width={width}
-        height={height}
+        width={handleSizeUnit(width)}
+        height={handleSizeUnit(height)}
         ref={targetRef}
         src={loaded ? src : placeholder}
         alt={alt}
@@ -72,11 +73,11 @@ export default Image;
 
 const LetterBoxDiv = styled.div<{
   letterBoxColor: ColorType;
-  width: number;
-  height: number;
+  width: number | string;
+  height: number | string;
 }>`
-  width: ${({ width }) => `${width}rem`};
-  height: ${({ height }) => `${height}rem`};
+  width: ${({ width }) => handleSizeUnit(width)};
+  height: ${({ height }) => handleSizeUnit(height)};
 
   background-color: ${({ letterBoxColor }) => `var(${letterBoxColor})`};
 
@@ -85,8 +86,8 @@ const LetterBoxDiv = styled.div<{
 const ImageStyled = styled.img<ImageStylePropsType>`
   display: ${({ block }) => (block ? 'block' : undefined)};
 
-  width: ${({ width }) => `${width}rem`};
-  height: ${({ height }) => `${height}rem`};
+  width: ${({ width }) => handleSizeUnit(width)};
+  height: ${({ height }) => handleSizeUnit(height)};
 
   object-fit: ${({ mode }) => mode};
 `;

--- a/src/constants/design.ts
+++ b/src/constants/design.ts
@@ -1,3 +1,4 @@
+import { AvatarSizeType } from '~/types/design/avatar';
 import ColorType from '~/types/design/color';
 import ContainerSizeType from '~/types/design/container';
 import {
@@ -132,4 +133,11 @@ export const CONTAINER_SIZE: { [K in ContainerSizeType]: string } = {
   md: '48rem',
   lg: '64rem',
   xl: '80rem',
+};
+
+export const AVATAR_SIZE_UNIT: AvatarSizeType[] = ['sm', 'lg'];
+
+export const AVATAR_SIZE: { [K in AvatarSizeType]: string } = {
+  sm: '2.5rem',
+  lg: '9.375rem',
 };

--- a/src/stories/Avatar.stories.tsx
+++ b/src/stories/Avatar.stories.tsx
@@ -1,0 +1,59 @@
+import Avatar, { AvatarPropsType } from '~/components/common/Avatar';
+
+export default {
+  title: 'Component/Avatar',
+  component: Avatar,
+  argTypes: {
+    lazy: {
+      control: { type: 'boolean' },
+    },
+    threshold: {
+      type: { name: 'number' },
+      control: { type: 'number' },
+    },
+    src: {
+      type: { name: 'string', require: true },
+      control: { type: 'text' },
+    },
+    placeholder: {
+      type: { name: 'string' },
+      control: { type: 'text' },
+    },
+    alt: {
+      control: 'text',
+    },
+    mode: {
+      options: ['cover', 'fill', 'contain'],
+      control: { type: 'inline-radio' },
+    },
+    size: {
+      options: ['sm', 'lg'],
+      control: { type: 'inline-radio' },
+    },
+    hoverColor: {
+      control: 'text',
+    },
+  },
+  args: {
+    src: 'https://picsum.photos/200',
+    threshold: 0.5,
+    size: 'lg',
+    handleClick: () => {
+      alert('프로필 페이지 이동');
+    },
+  },
+};
+
+export const Small = (args: AvatarPropsType) => {
+  return <Avatar {...args} />;
+};
+
+export const Lazy = (args: AvatarPropsType) => {
+  return (
+    <div>
+      {Array.from(new Array(20), (_, k) => k).map(() => (
+        <Avatar {...args} />
+      ))}
+    </div>
+  );
+};

--- a/src/stories/Avatar.stories.tsx
+++ b/src/stories/Avatar.stories.tsx
@@ -44,11 +44,11 @@ export default {
   },
 };
 
-export const Small = (args: AvatarPropsType) => {
+export const Default = (args: AvatarPropsType) => {
   return <Avatar {...args} />;
 };
 
-export const Lazy = (args: AvatarPropsType) => {
+export const LazyTest = (args: AvatarPropsType) => {
   return (
     <div>
       {Array.from(new Array(20), (_, k) => k).map(() => (

--- a/src/types/design/avatar.ts
+++ b/src/types/design/avatar.ts
@@ -1,0 +1,1 @@
+export type AvatarSizeType = 'sm' | 'lg';

--- a/src/utils/handleSizeUnit.ts
+++ b/src/utils/handleSizeUnit.ts
@@ -1,0 +1,3 @@
+export const handleSizeUnit = (size: string | number) => {
+  return typeof size === 'number' ? `${size}rem` : size;
+};


### PR DESCRIPTION
## :rocket: 주요 작업 내용
Image 컴포넌트를 활용하여 Avatar 컴포넌트를 구현했습니다
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/88219703/e277d9e5-6bb7-4d7b-9dd9-c338619eab6a)


### 기능
- Image 기본으로 lazy loading (lazy loading, threshold 설정 가능)
- size는 `sm` (40px X 40px)과 `lg` (150px X 150px) 제공
- Avatar hover 시 borderColor 변경. borderColor 변경 가능
- Avatar 클릭 이벤트 핸들러 주입 필요
## :pushpin: 스크린샷

## :white_check_mark: 고민 중인 부분 및 참고사항
- [ ] 현재 Avatar 단위 타입을 types폴더 안에 별도의 파일에 정의했는데 각 컴포넌트 별로 별도의 파일을 만들어 단위를 정의할지 고민입니다
- [ ] handleClick props로 이벤트 핸들러를 주입합니다. Avatar마다 내부적으로 useNavigate 훅을 불러오는 것보다 상위 컴포넌트에서 한번 호출 후, Avatar에 내려주는 방식으로 생각해봤는데 적절한지 궁금합니다
- [ ] UI나 로직에서 수정할 부분 있으면 알려주세요

Closes #47 