### PR TITLE
[31] Toast 컴포넌트 구현

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,102 @@
+import styled, { keyframes } from 'styled-components';
+import Flex from '~/components/common/Flex';
+import Text from '~/components/common/Text';
+import ColorType from '~/types/design/color';
+import { FontSizeType, FontWeightType } from '~/types/design/font';
+import { Property } from 'csstype';
+
+interface ToastPropsType {
+  text: string;
+  size?: FontSizeType;
+  weight?: FontWeightType;
+  color?: ColorType;
+  borderColor?: ColorType;
+  progressBarColor?: ColorType;
+  progressBarHeight?: number;
+  position?: 'top' | 'bottom' | 'center';
+  time?: number;
+}
+
+interface SpacerPropsType {
+  padding: Property.Padding;
+}
+
+const Toast = ({
+  text,
+  size = 'md' as FontSizeType,
+  weight = 400,
+  color = '--primaryColor' as ColorType,
+  borderColor = '--primaryColor' as ColorType,
+  progressBarColor = '--primaryColor' as ColorType,
+  progressBarHeight = 1,
+  // position = 'top', //TODO
+  time = 3000,
+}: ToastPropsType) => {
+  const Spacer = styled.div<SpacerPropsType>`
+    padding: ${(props) => `${props.padding}`};
+  `;
+
+  const ProgressBarContainer = styled.div`
+    width: 100%;
+    height: ${progressBarHeight}rem;
+
+    background-color: var(--adaptive50);
+  `;
+
+  const progress = keyframes`
+  from{
+    width: 100%;
+  }
+
+  to{
+    width: 0%
+  }
+  `;
+
+  const ProgressBar = styled.div`
+    width: 100%;
+    height: 1rem;
+
+    background-color: var(${progressBarColor});
+
+    animation: ${progress} ${time}ms ease-in;
+
+    animation-fill-mode: forwards;
+  `;
+
+  const CloseButton = styled.button`
+    width: 1rem;
+    height: 1rem;
+  `;
+
+  const Container = styled.div`
+    width: 25rem;
+    border: 0.075rem solid var(${borderColor});
+  `;
+
+  return (
+    <Container>
+      <Flex direction='column'>
+        <Spacer padding={'0.75rem 0.75rem 1.25rem 0.75rem'}>
+          <Flex direction='column'>
+            <Flex justifyContent='flex-end'>
+              <CloseButton>x</CloseButton>
+            </Flex>
+            <Text
+              color={color}
+              weight={weight}
+              size={size}
+            >
+              {text}
+            </Text>
+          </Flex>
+        </Spacer>
+        <ProgressBarContainer>
+          <ProgressBar />
+        </ProgressBarContainer>
+      </Flex>
+    </Container>
+  );
+};
+
+export default Toast;

--- a/src/stories/Toast.stories.ts
+++ b/src/stories/Toast.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Toast from '../components/Toast';
+import ColorType from '~/types/design/color';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Components/Common/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Toast>;
+
+export const Standard: Story = {
+  args: {
+    text: '포스트를 삭제했어요',
+    size: 'md',
+    weight: 400,
+    color: '--primaryColor' as ColorType,
+    borderColor: '--primaryColor' as ColorType,
+    progressBarColor: '--primaryColor' as ColorType,
+    progressBarHeight: 1,
+    time: 3000,
+  },
+};


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- Toast 컴포넌트를 구현했습니다.
- progress bar 감소 애니매이션

## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86847564/71a826c5-f493-4585-836d-97288e3d97c6)

## :white_check_mark: 고민 중인 부분 및 참고사항
- 닫기 버튼은 추후에 교체하려고 합니다
- position을 추후 추가하려고 합니다.
- [ ] 타입과 초기화 부분 확인 부탁드립니다.
- [ ] 컴포넌트 커스텀이 가능하도록 props를 받아서 styled component에 전달했는데, 복잡하지 않은지 확인 부탁드립니다.
- [ ] 폴더를 생성하는게 좋을까요?

<!-- ## 이슈 번호 close -->
close #31
