### PR TITLE
[34] Loading 컴포넌트 구현

### DIFF
--- a/src/components/loading/CircleLoading.tsx
+++ b/src/components/loading/CircleLoading.tsx
@@ -1,5 +1,6 @@
-import styled, { keyframes } from 'styled-components';
+import Container from '../common/Container';
 import ColorType from '~/types/design/color';
+import styled, { keyframes } from 'styled-components';
 
 interface CircleLoadingPropsType {
   size?: number;
@@ -8,6 +9,24 @@ interface CircleLoadingPropsType {
   primaryColor?: ColorType;
   secondaryColor?: ColorType;
 }
+
+interface AnimationPropsType {
+  time: number;
+}
+
+const rotateBar = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const Animation = styled.div<AnimationPropsType>`
+  animation: ${rotateBar} ${({ time }) => time}s linear infinite;
+`;
 
 const CircleLoading = ({
   size = 7.5,
@@ -23,45 +42,37 @@ const CircleLoading = ({
   const secondaryColorBarRatio = ((circleRadius * 2 * Math.PI) / 5) * 4;
   const newStrokeWidth = strokeWidth < 0 ? 0 : strokeWidth;
 
-  const rotateBar = keyframes`
-    100% {
-        transform: rotate(360deg);
-}
-  `;
-
-  const Container = styled.div`
-    width: ${newSize}rem;
-    height: ${newSize}rem;
-
-    animation: ${rotateBar} ${time}s linear infinite;
-  `;
-
   return (
-    <Container>
-      <svg
-        width={convertedSize}
-        height={convertedSize}
-        viewBox={`0 0 ${convertedSize} ${convertedSize}`}
-      >
-        <circle
-          cx={circleRadius * 2}
-          cy={circleRadius * 2}
-          r={circleRadius}
-          stroke-width={newStrokeWidth}
-          fill='none'
-          style={{ stroke: `var(${secondaryColor})` }}
-        />
-        <circle
-          cx={circleRadius * 2}
-          cy={circleRadius * 2}
-          r={circleRadius}
-          stroke-width={newStrokeWidth}
-          fill='none'
-          style={{ stroke: `var(${primaryColor})` }}
-          stroke-dasharray={`${primaryColorBarRatio} ${secondaryColorBarRatio}`}
-          stroke-linecap='round'
-        />
-      </svg>
+    <Container
+      maxWidth={'sm'}
+      style={{ width: `${newSize}rem`, height: `${newSize}rem` }}
+    >
+      <Animation time={time}>
+        <svg
+          width={convertedSize}
+          height={convertedSize}
+          viewBox={`0 0 ${convertedSize} ${convertedSize}`}
+        >
+          <circle
+            cx={circleRadius * 2}
+            cy={circleRadius * 2}
+            r={circleRadius}
+            stroke-width={newStrokeWidth}
+            fill='none'
+            style={{ stroke: `var(${secondaryColor})` }}
+          />
+          <circle
+            cx={circleRadius * 2}
+            cy={circleRadius * 2}
+            r={circleRadius}
+            stroke-width={newStrokeWidth}
+            fill='none'
+            style={{ stroke: `var(${primaryColor})` }}
+            stroke-dasharray={`${primaryColorBarRatio} ${secondaryColorBarRatio}`}
+            stroke-linecap='round'
+          />
+        </svg>
+      </Animation>
     </Container>
   );
 };

--- a/src/components/loading/CircleLoading.tsx
+++ b/src/components/loading/CircleLoading.tsx
@@ -1,0 +1,66 @@
+import styled, { keyframes } from 'styled-components';
+import ColorType from '~/types/design/color';
+
+interface CircleLoadingPropsType {
+  size?: number;
+  time?: number;
+  primaryColor?: ColorType;
+  secondaryColor?: ColorType;
+}
+
+const CircleLoading = ({
+  size = 7.5,
+  time = 2,
+  primaryColor = '--primaryColor' as ColorType,
+  secondaryColor = '--adaptive300' as ColorType,
+}: CircleLoadingPropsType) => {
+  const newSize = size < 2 ? 2 : size;
+  const convertedSize = newSize * 16;
+  const circleRadius = convertedSize / 4;
+  const primaryColorBarRatio = (circleRadius * 2 * Math.PI) / 5;
+  const secondaryColorBarRatio = ((circleRadius * 2 * Math.PI) / 5) * 4;
+
+  const rotateBar = keyframes`
+    100% {
+        transform: rotate(360deg);
+}
+  `;
+
+  const Container = styled.div`
+    width: ${newSize}rem;
+    height: ${newSize}rem;
+
+    animation: ${rotateBar} ${time}s linear infinite;
+  `;
+
+  return (
+    <Container>
+      <svg
+        width={convertedSize}
+        height={convertedSize}
+        viewBox={`0 0 ${convertedSize} ${convertedSize}`}
+      >
+        <circle
+          cx={circleRadius * 2}
+          cy={circleRadius * 2}
+          r={circleRadius}
+          stroke-width='12'
+          fill='none'
+          style={{ stroke: `var(${secondaryColor})` }}
+        />
+        <circle
+          cx={circleRadius * 2}
+          cy={circleRadius * 2}
+          r={circleRadius}
+          stroke-width='12'
+          fill='none'
+          style={{ stroke: `var(${primaryColor})` }}
+          stroke-dasharray={`${primaryColorBarRatio} ${secondaryColorBarRatio}`}
+          stroke-linecap='round'
+        />
+      </svg>
+    </Container>
+  );
+};
+
+export default CircleLoading;

--- a/src/components/loading/CircleLoading.tsx
+++ b/src/components/loading/CircleLoading.tsx
@@ -5,9 +5,9 @@ import styled, { keyframes } from 'styled-components';
 interface CircleLoadingPropsType {
   size?: number;
   time?: number;
-  strokeWidth?: number;
-  primaryColor?: ColorType;
-  secondaryColor?: ColorType;
+  stroke?: number;
+  color?: ColorType;
+  backgroundColor?: ColorType;
 }
 
 interface AnimationPropsType {
@@ -31,16 +31,16 @@ const Animation = styled.div<AnimationPropsType>`
 const CircleLoading = ({
   size = 7.5,
   time = 2,
-  strokeWidth = 12,
-  primaryColor = '--primaryColor' as ColorType,
-  secondaryColor = '--adaptive300' as ColorType,
+  stroke = 12,
+  color = '--primaryColor' as ColorType,
+  backgroundColor = '--adaptive300' as ColorType,
 }: CircleLoadingPropsType) => {
   const newSize = size < 2 ? 2 : size;
   const convertedSize = newSize * 16;
   const circleRadius = convertedSize / 4;
-  const primaryColorBarRatio = (circleRadius * 2 * Math.PI) / 5;
-  const secondaryColorBarRatio = ((circleRadius * 2 * Math.PI) / 5) * 4;
-  const newStrokeWidth = strokeWidth < 0 ? 0 : strokeWidth;
+  const colorBarRatio = (circleRadius * 2 * Math.PI) / 5;
+  const backgroundColorBarRatio = ((circleRadius * 2 * Math.PI) / 5) * 4;
+  const newStrokeWidth = stroke < 0 ? 0 : stroke;
 
   return (
     <Container
@@ -59,7 +59,7 @@ const CircleLoading = ({
             r={circleRadius}
             stroke-width={newStrokeWidth}
             fill='none'
-            style={{ stroke: `var(${secondaryColor})` }}
+            style={{ stroke: `var(${backgroundColor})` }}
           />
           <circle
             cx={circleRadius * 2}
@@ -67,8 +67,8 @@ const CircleLoading = ({
             r={circleRadius}
             stroke-width={newStrokeWidth}
             fill='none'
-            style={{ stroke: `var(${primaryColor})` }}
-            stroke-dasharray={`${primaryColorBarRatio} ${secondaryColorBarRatio}`}
+            style={{ stroke: `var(${color})` }}
+            stroke-dasharray={`${colorBarRatio} ${backgroundColorBarRatio}`}
             stroke-linecap='round'
           />
         </svg>

--- a/src/components/loading/CircleLoading.tsx
+++ b/src/components/loading/CircleLoading.tsx
@@ -4,6 +4,7 @@ import ColorType from '~/types/design/color';
 interface CircleLoadingPropsType {
   size?: number;
   time?: number;
+  strokeWidth?: number;
   primaryColor?: ColorType;
   secondaryColor?: ColorType;
 }
@@ -11,6 +12,7 @@ interface CircleLoadingPropsType {
 const CircleLoading = ({
   size = 7.5,
   time = 2,
+  strokeWidth = 12,
   primaryColor = '--primaryColor' as ColorType,
   secondaryColor = '--adaptive300' as ColorType,
 }: CircleLoadingPropsType) => {
@@ -19,6 +21,7 @@ const CircleLoading = ({
   const circleRadius = convertedSize / 4;
   const primaryColorBarRatio = (circleRadius * 2 * Math.PI) / 5;
   const secondaryColorBarRatio = ((circleRadius * 2 * Math.PI) / 5) * 4;
+  const newStrokeWidth = strokeWidth < 0 ? 0 : strokeWidth;
 
   const rotateBar = keyframes`
     100% {
@@ -44,7 +47,7 @@ const CircleLoading = ({
           cx={circleRadius * 2}
           cy={circleRadius * 2}
           r={circleRadius}
-          stroke-width='12'
+          stroke-width={newStrokeWidth}
           fill='none'
           style={{ stroke: `var(${secondaryColor})` }}
         />
@@ -52,7 +55,7 @@ const CircleLoading = ({
           cx={circleRadius * 2}
           cy={circleRadius * 2}
           r={circleRadius}
-          stroke-width='12'
+          stroke-width={newStrokeWidth}
           fill='none'
           style={{ stroke: `var(${primaryColor})` }}
           stroke-dasharray={`${primaryColorBarRatio} ${secondaryColorBarRatio}`}

--- a/src/stories/components/CircleLoading.stories.ts
+++ b/src/stories/components/CircleLoading.stories.ts
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import CircleLoading from '~/components/loading/CircleLoading';
 
 const meta: Meta<typeof CircleLoading> = {
-  title: 'Components/Common/CircleLoading',
+  title: 'Component/CircleLoading',
   component: CircleLoading,
   tags: ['autodocs'],
   argTypes: {},

--- a/src/stories/components/CircleLoading.stories.ts
+++ b/src/stories/components/CircleLoading.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CircleLoading from '~/components/loading/CircleLoading';
+
+const meta: Meta<typeof CircleLoading> = {
+  title: 'Components/Common/CircleLoading',
+  component: CircleLoading,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CircleLoading>;
+
+export const Standard: Story = {
+  args: {
+    size: 7.5,
+    time: 2,
+    primaryColor: '--primaryColor',
+    secondaryColor: '--adaptive300',
+  },
+};

--- a/src/stories/components/CircleLoading.stories.ts
+++ b/src/stories/components/CircleLoading.stories.ts
@@ -17,6 +17,7 @@ export const Standard: Story = {
   args: {
     size: 7.5,
     time: 2,
+    strokeWidth: 12,
     primaryColor: '--primaryColor',
     secondaryColor: '--adaptive300',
   },


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- Loading 컴포넌트를 구현했습니다.

## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86847564/8b0c2c4b-9f93-4d46-b861-ad52ca27a1cf)

## :white_check_mark: 고민 중인 부분 및 참고사항
- [ ] size는 원의 크기를 나타냅니다. 2 이하의 값을 작성하면 2로 지정됩니다.
- [ ] time은 회전 속도를 나타냅니다. 숫자가 작아질수록 빠르게 회전합니다.
- [ ] primaryColor와 secondaryColor로 색상을 지정할 수 있습니다.
- [ ] 내부에 원과 관련된 계산 수식이 필요해서 따로 변수로 지정했습니다.

<!-- ## 이슈 번호 close -->
close #34 