### PR TITLE
[46] Button 재사용 컴포넌트 구현

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,92 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+import ColorType from '~/types/design/color';
+import { ButtonSizeType, ButtonVariantType } from '~/types/design/button';
+import { FONT_SIZE, FONT_SIZE_UNIT } from '~/constants/design';
+
+export interface ButtonPropsType {
+  variant: ButtonVariantType;
+  size: ButtonSizeType;
+  color: ColorType;
+  leftItem?: ReactNode;
+  rightItem?: ReactNode;
+  m?: number;
+  mx?: number;
+  my?: number;
+  mt?: number;
+  mb?: number;
+  ml?: number;
+  mr?: number;
+}
+
+const StyledButton = styled.button<ButtonPropsType>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin: ${({ m }) => (m ? `${m}rem` : undefined)};
+  margin-top: ${({ mt, my }) =>
+    mt ? `${mt}rem` : my ? `${my}rem` : undefined};
+  margin-right: ${({ mr, mx }) =>
+    mr ? `${mr}rem` : mx ? `${mx}rem` : undefined};
+  margin-bottom: ${({ mb, my }) =>
+    mb ? `${mb}rem` : my ? `${my}rem` : undefined};
+  margin-left: ${({ ml, mx }) =>
+    ml ? `${ml}rem` : mx ? `${mx}rem` : undefined};
+  padding: 0.5em 1em;
+  border: 0.125rem solid;
+  border-radius: 0.25rem;
+
+  background-color: ${({ variant, color }) =>
+    variant === 'filled' ? `var(${color})` : 'var(--transparent)'};
+
+  color: ${({ variant, color }) =>
+    variant === 'filled' ? 'var(--white)' : `var(${color})`};
+  font-weight: 600;
+  font-size: ${({ size }) =>
+    FONT_SIZE[FONT_SIZE_UNIT.find((_, i, arr) => arr[i + 1] === size) ?? size]};
+
+  border-color: ${({ variant, color }) =>
+    variant === 'outlined' ? `var(${color})` : 'var(--transparent)'};
+
+  box-sizing: border-box;
+
+  cursor: pointer;
+  font-family: inherit;
+  gap: 0.5rem;
+  transition-duration: 250ms;
+  transition-property: filter, background-color;
+
+  &:disabled {
+    background-color: ${({ variant }) =>
+      variant === 'filled' ? 'var(--adaptive200)' : 'var(--transparent)'};
+
+    color: var(--adaptive400);
+
+    border-color: ${({ variant }) =>
+      variant === 'outlined' ? 'var(--adaptive300)' : 'var(--transparent)'};
+
+    cursor: not-allowed;
+  }
+
+  &:enabled:hover {
+    ${({ variant }) =>
+      variant === 'filled'
+        ? `filter: saturate(0.8);`
+        : `background-color: var(--adaptive200);`}
+  }
+`;
+
+const Button: React.FC<React.ComponentProps<typeof StyledButton>> = ({
+  ...args
+}) => {
+  return (
+    <StyledButton {...args}>
+      {args.leftItem}
+      {args.children}
+      {args.rightItem}
+    </StyledButton>
+  );
+};
+
+export default Button;

--- a/src/constants/design.ts
+++ b/src/constants/design.ts
@@ -1,3 +1,4 @@
+import { ButtonSizeType, ButtonVariantType } from '~/types/design/button';
 import ColorType from '~/types/design/color';
 import ContainerSizeType from '~/types/design/container';
 import {
@@ -11,7 +12,7 @@ export const COLOR: ColorType[] = [
   '--secondaryColor',
   '--white',
   '--black',
-  '--ransparent',
+  '--transparent',
   '--adaptive50',
   '--adaptive100',
   '--adaptive200',
@@ -136,3 +137,11 @@ export const CONTAINER_SIZE: { [K in ContainerSizeType]: string } = {
   lg: '64rem',
   xl: '80rem',
 };
+
+export const BUTTON_VARIANT: ButtonVariantType[] = [
+  'filled',
+  'outlined',
+  'text',
+];
+
+export const BUTTON_SIZE_UNIT: ButtonSizeType[] = ['sm', 'md', 'lg'];

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,0 +1,64 @@
+import { IconArrowRight, IconUser } from '@tabler/icons-react';
+import Button, { ButtonPropsType } from '~/components/common/Button';
+import Container from '~/components/common/Container';
+import { BUTTON_VARIANT, BUTTON_SIZE_UNIT, COLOR } from '~/constants/design';
+
+export default {
+  title: 'Component/Button',
+  component: Button,
+  argTypes: {
+    variant: { control: 'select', options: BUTTON_VARIANT },
+    size: { control: 'select', options: BUTTON_SIZE_UNIT },
+    color: { control: 'select', options: COLOR },
+    disabled: { control: 'boolean' },
+    m: { control: 'number' },
+    mx: { control: 'number' },
+    my: { control: 'number' },
+    mt: { control: 'number' },
+    mb: { control: 'number' },
+    ml: { control: 'number' },
+    mr: { control: 'number' },
+  },
+  args: {
+    variant: 'filled',
+    size: 'md',
+    color: '--primaryColor',
+    children: '버튼',
+  },
+};
+
+export const Text = (args: ButtonPropsType) => {
+  return (
+    <Container maxWidth='md'>
+      <Button
+        {...args}
+        onClick={() => alert('click')}
+      />
+    </Container>
+  );
+};
+
+export const Icon = (args: ButtonPropsType) => {
+  return (
+    <Container maxWidth='md'>
+      <Button
+        {...args}
+        leftItem={
+          <IconUser
+            size={16}
+            stroke={3}
+          />
+        }
+        rightItem={
+          <IconArrowRight
+            size={16}
+            stroke={3}
+          />
+        }
+        onClick={() => alert('click')}
+      >
+        로그인
+      </Button>
+    </Container>
+  );
+};

--- a/src/types/design/button.ts
+++ b/src/types/design/button.ts
@@ -1,0 +1,2 @@
+export type ButtonVariantType = 'filled' | 'outlined' | 'text';
+export type ButtonSizeType = 'sm' | 'md' | 'lg';

--- a/src/types/design/color.ts
+++ b/src/types/design/color.ts
@@ -3,7 +3,7 @@ type ColorType =
   | '--secondaryColor'
   | '--white'
   | '--black'
-  | '--ransparent'
+  | '--transparent'
   | '--adaptive50'
   | '--adaptive100'
   | '--adaptive200'


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- Button 재사용 컴포넌트 구현

## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86952779/f07bab4b-1cbb-4572-9725-c3e3b5a9e9f5)

## :white_check_mark: 고민 중인 부분 및 참고사항
- [ ] filled, outlined, text 세가지 variant가 제공됩니다.
- [ ] sm, md, lg 세가지 size가 제공됩니다.
- [ ] leftItem, rightItem를 이용해 원하는 아이콘을 넣을 수 있습니다.

close #46 