### PR TITLE
[49] DropDown 컴포넌트 구현

### DIFF
--- a/src/components/dropDown/DropDown.tsx
+++ b/src/components/dropDown/DropDown.tsx
@@ -8,7 +8,7 @@ export interface DropDownListItemType {
 export interface DropDownPropsType {
   isDropped: boolean;
   list: DropDownListItemType[];
-  handleClick: (href: string) => void;
+  onDropDownItemClick: (actionType: string) => void;
 }
 
 interface DropDownMenuProps {

--- a/src/components/dropDown/DropDown.tsx
+++ b/src/components/dropDown/DropDown.tsx
@@ -1,0 +1,98 @@
+import styled, { css } from 'styled-components';
+
+export interface DropDownListItemType {
+  title: string;
+  href: string;
+}
+
+export interface DropDownPropsType {
+  isDropped: boolean;
+  list: DropDownListItemType[];
+  handleClick: (href: string) => void;
+}
+
+interface DropDownMenuProps {
+  isDropped: boolean;
+}
+
+const DropDown = ({ isDropped, list, handleClick }: DropDownPropsType) => {
+  return (
+    <DropDownContainer>
+      <DropDownContent isDropped={isDropped}>
+        <DropDownUl>
+          {list.map((item) => (
+            <DropDownLi
+              key={item.title}
+              onClick={() => handleClick(item.href)}
+            >
+              {item.title}
+            </DropDownLi>
+          ))}
+        </DropDownUl>
+      </DropDownContent>
+    </DropDownContainer>
+  );
+};
+
+const DropDownContainer = styled.div`
+  position: relative;
+  max-width: 2.75rem;
+  margin: 0 auto;
+`;
+
+const DropDownContent = styled.div<DropDownMenuProps>`
+  position: absolute;
+  top: 3.25rem;
+  left: 50%;
+  display: flex;
+  width: 10.625rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 1px;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.25rem 0.875rem 0 var(--adaptiveOpacity200);
+  visibility: hidden;
+  transform: translate(-50%, -20px);
+  transition:
+    opacity 0.4s ease,
+    transform 0.4s ease,
+    visibility 0.4s;
+  z-index: 9;
+
+  ${({ isDropped }) =>
+    isDropped &&
+    css`
+      opacity: 1;
+      visibility: visible;
+      transform: translate(-50%, 0);
+      left: 50%;
+    `};
+`;
+
+const DropDownUl = styled.ul`
+  width: 100%;
+  :not(:last-child) {
+    border-bottom: 1px solid var(--adaptive300);
+  }
+  :first-child {
+    border-radius: 0.5rem 0.5rem 0 0;
+  }
+  :last-child {
+    border-radius: 0 0 0.5rem 0.5rem;
+  }
+`;
+
+const DropDownLi = styled.li`
+  cursor: pointer;
+  display: block;
+  padding: 0.75rem 1rem;
+  width: 100%;
+  box-sizing: border-box;
+
+  &:hover {
+    background-color: var(--adaptive300);
+  }
+`;
+
+export default DropDown;

--- a/src/components/dropDown/DropDown.tsx
+++ b/src/components/dropDown/DropDown.tsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 
 export interface DropDownListItemType {
   title: string;
-  href: string;
+  action: string;
 }
 
 export interface DropDownPropsType {
@@ -15,7 +15,17 @@ interface DropDownMenuProps {
   isDropped: boolean;
 }
 
-const DropDown = ({ isDropped, list, handleClick }: DropDownPropsType) => {
+const DropDown = ({
+  isDropped,
+  list,
+  onDropDownItemClick,
+}: DropDownPropsType) => {
+  const handleClick = (actionType: string) => {
+    if (onDropDownItemClick) {
+      onDropDownItemClick(actionType);
+    }
+  };
+
   return (
     <DropDownContainer>
       <DropDownContent isDropped={isDropped}>
@@ -23,7 +33,7 @@ const DropDown = ({ isDropped, list, handleClick }: DropDownPropsType) => {
           {list.map((item) => (
             <DropDownLi
               key={item.title}
-              onClick={() => handleClick(item.href)}
+              onClick={() => handleClick(item.action)}
             >
               {item.title}
             </DropDownLi>
@@ -55,17 +65,17 @@ const DropDownContent = styled.div<DropDownMenuProps>`
   visibility: hidden;
   transform: translate(-50%, -20px);
   transition:
-    opacity 0.4s ease,
-    transform 0.4s ease,
+    opacity 0.4s ease-in-out,
+    transform 0.4s ease-in-out,
     visibility 0.4s;
-  z-index: 9;
+  z-index: 10;
 
   ${({ isDropped }) =>
     isDropped &&
     css`
       opacity: 1;
       visibility: visible;
-      transform: translate(-50%, 0);
+      transform: translate(-50%, 1.25rem);
       left: 50%;
     `};
 `;

--- a/src/components/dropDown/DropDown.tsx
+++ b/src/components/dropDown/DropDown.tsx
@@ -46,59 +46,68 @@ const DropDown = ({
 
 const DropDownContainer = styled.div`
   position: relative;
+
   max-width: 2.75rem;
   margin: 0 auto;
 `;
 
+const TestStyle = css`
+  visibility: visible;
+  left: 50%;
+
+  opacity: 1;
+  transform: translate(-50%, 1.25rem);
+`;
 const DropDownContent = styled.div<DropDownMenuProps>`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  visibility: hidden;
   position: absolute;
   top: 3.25rem;
   left: 50%;
-  display: flex;
+  z-index: 10;
+
   width: 10.625rem;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
-  gap: 1px;
   border-radius: 0.5rem;
   box-shadow: 0 0.25rem 0.875rem 0 var(--adaptiveOpacity200);
-  visibility: hidden;
+
+  gap: 1px;
+
   transform: translate(-50%, -20px);
   transition:
     opacity 0.4s ease-in-out,
     transform 0.4s ease-in-out,
     visibility 0.4s;
-  z-index: 10;
 
-  ${({ isDropped }) =>
-    isDropped &&
-    css`
-      opacity: 1;
-      visibility: visible;
-      transform: translate(-50%, 1.25rem);
-      left: 50%;
-    `};
+  ${({ isDropped }) => isDropped && TestStyle}
 `;
 
 const DropDownUl = styled.ul`
   width: 100%;
+
   :not(:last-child) {
     border-bottom: 1px solid var(--adaptive300);
   }
+
   :first-child {
     border-radius: 0.5rem 0.5rem 0 0;
   }
+
   :last-child {
     border-radius: 0 0 0.5rem 0.5rem;
   }
 `;
 
 const DropDownLi = styled.li`
-  cursor: pointer;
   display: block;
-  padding: 0.75rem 1rem;
+
   width: 100%;
+  padding: 0.75rem 1rem;
+
   box-sizing: border-box;
+  cursor: pointer;
 
   &:hover {
     background-color: var(--adaptive300);

--- a/src/hooks/useDetectClose.tsx
+++ b/src/hooks/useDetectClose.tsx
@@ -1,0 +1,31 @@
+import { useState, useRef, useEffect, MouseEventHandler } from 'react';
+
+const useDetectClose = (initialState: boolean) => {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const ref = useRef<HTMLButtonElement>(null);
+
+  const removeHandler: MouseEventHandler<HTMLButtonElement> = () => {
+    setIsOpen(!isOpen);
+  };
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (ref.current !== null && !ref.current.contains(e.target as Node)) {
+        setIsOpen(!isOpen);
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('click', onClick);
+    }
+
+    return () => {
+      window.removeEventListener('click', onClick);
+    };
+  }, [isOpen]);
+
+  return [isOpen, ref, removeHandler] as const;
+};
+
+export default useDetectClose;

--- a/src/stories/components/DropDown.stories.tsx
+++ b/src/stories/components/DropDown.stories.tsx
@@ -21,8 +21,8 @@ export const Default = (args: DropDownPropsType) => {
 
 Default.args = {
   list: [
-    { title: '수정하기', href: '#1' },
-    { title: '삭제하기', href: '#2' },
+    { title: '수정하기', action: 'put' },
+    { title: '삭제하기', action: 'delete' },
   ],
   isDropped: true,
 };

--- a/src/stories/components/DropDown.stories.tsx
+++ b/src/stories/components/DropDown.stories.tsx
@@ -1,0 +1,28 @@
+import DropDown, { DropDownPropsType } from '~/components/dropDown/DropDown';
+
+export default {
+  title: 'Component/DropDown',
+  component: DropDown,
+  argTypes: {
+    list: {
+      type: { name: 'array' },
+      description: '더보기 목록들',
+      control: {
+        type: 'array',
+        separator: ',',
+      },
+    },
+  },
+};
+
+export const Default = (args: DropDownPropsType) => {
+  return <DropDown {...args}></DropDown>;
+};
+
+Default.args = {
+  list: [
+    { title: '수정하기', href: '#1' },
+    { title: '삭제하기', href: '#2' },
+  ],
+  isDropped: true,
+};


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- DropDown 컴포넌트 구현
- props로 list를 받아와 DropDown을 생성

## :pushpin: 스크린샷
<img width="810" alt="스크린샷 2024-01-04 오후 9 17 14" src="https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/62047243/0bc34319-501b-4027-98b8-3a92f4dac7c5">

## :white_check_mark: 고민 중인 부분 및 참고사항

- [ ] map으로 `DropDownLi`를 생성할 때 key 값으로 `item.title`을 넣었는데 그냥 index로 넣는 게 좋을까요?

<!-- ## 이슈 번호 close -->
Closes #49 