### PR TITLE
[70] 피드 List Item 컴포넌트 구현

### DIFF
--- a/src/components/feed/FeedFooterItem.tsx
+++ b/src/components/feed/FeedFooterItem.tsx
@@ -17,7 +17,7 @@ const FeedFooterItem = ({
   return (
     <Flex
       alignItems='center'
-      ml={1}
+      ml={iconType === 'like' ? 0 : 1}
     >
       {iconType === 'like' ? (
         <IconHeart

--- a/src/components/feed/FeedFooterItem.tsx
+++ b/src/components/feed/FeedFooterItem.tsx
@@ -1,25 +1,37 @@
 import Flex from '~/components/common/Flex';
-import Image from '~/components/common/Image';
 import Text from '~/components/common/Text';
+import { IconHeart } from '@tabler/icons-react';
+import { IconMessageCircle2 } from '@tabler/icons-react';
 
 export interface FeedFooterItemPropTypes {
-  iconImg: string;
+  iconType: string;
   title: string;
   count: number;
 }
 
-const FeedFooterItem = ({ iconImg, title, count }: FeedFooterItemPropTypes) => {
+const FeedFooterItem = ({
+  iconType,
+  title,
+  count,
+}: FeedFooterItemPropTypes) => {
   return (
     <Flex
       alignItems='center'
       style={{ marginRight: '1rem' }}
     >
-      <Image
-        width={1.125}
-        height={1.125}
-        src={iconImg}
-        alt='icon image'
-      ></Image>
+      {iconType === 'like' ? (
+        <IconHeart
+          width='1.4rem'
+          height='1.4rem'
+          color='var(--adaptive500)'
+        ></IconHeart>
+      ) : (
+        <IconMessageCircle2
+          width='1.4rem'
+          height='1.4rem'
+          color='var(--adaptive500)'
+        ></IconMessageCircle2>
+      )}
       <Text style={{ marginLeft: '0.2rem', color: 'var(--adaptive500)' }}>
         {title}
       </Text>

--- a/src/components/feed/FeedFooterItem.tsx
+++ b/src/components/feed/FeedFooterItem.tsx
@@ -17,7 +17,7 @@ const FeedFooterItem = ({
   return (
     <Flex
       alignItems='center'
-      style={{ marginRight: '1rem' }}
+      ml={1}
     >
       {iconType === 'like' ? (
         <IconHeart

--- a/src/components/feed/FeedFooterItem.tsx
+++ b/src/components/feed/FeedFooterItem.tsx
@@ -1,0 +1,33 @@
+import Flex from '~/components/common/Flex';
+import Image from '~/components/common/Image';
+import Text from '~/components/common/Text';
+
+export interface FeedFooterItemPropTypes {
+  iconImg: string;
+  title: string;
+  count: number;
+}
+
+const FeedFooterItem = ({ iconImg, title, count }: FeedFooterItemPropTypes) => {
+  return (
+    <Flex
+      alignItems='center'
+      style={{ marginRight: '1rem' }}
+    >
+      <Image
+        width={1.125}
+        height={1.125}
+        src={iconImg}
+        alt='icon image'
+      ></Image>
+      <Text style={{ marginLeft: '0.2rem', color: 'var(--adaptive500)' }}>
+        {title}
+      </Text>
+      <Text style={{ marginLeft: '0.4rem', color: 'var(--adaptive500)' }}>
+        {count}개
+      </Text>
+    </Flex>
+  );
+};
+
+export default FeedFooterItem;

--- a/src/components/feed/FeedListItem.tsx
+++ b/src/components/feed/FeedListItem.tsx
@@ -1,0 +1,142 @@
+import Container from '~/components/common/Container';
+import Flex from '~/components/common/Flex';
+import Text from '~/components/common/Text';
+import Image from '~/components/common/Image';
+import styled from 'styled-components';
+import FeedFooterItem from './FeedFooterItem';
+
+export interface FeedListItemPropTypes {
+  id: string;
+  userId: string;
+  profileImage: string;
+  userName: string;
+  date: string;
+  content: string;
+  imageUrl?: string;
+  likesCount: number;
+  commentsCount: number;
+  onFeedClick: (feedId: string) => void;
+  onUserClick: (userId: string) => void;
+}
+
+const Divider = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: var(--adaptive400);
+  margin: 1rem 0;
+`;
+
+const FeedListItem = ({
+  id,
+  userId,
+  profileImage,
+  userName,
+  date,
+  content,
+  imageUrl,
+  likesCount,
+  commentsCount,
+  onFeedClick,
+  onUserClick,
+}: FeedListItemPropTypes) => {
+  // 피드 클릭 시
+  const handleFeedClick = (feedId: string) => {
+    if (onFeedClick) {
+      onFeedClick(feedId);
+      alert(feedId);
+    }
+  };
+
+  // 사용자 이미지 클릭 시
+  const handleUserClick = (
+    userId: string,
+    e: React.MouseEvent<HTMLDivElement>
+  ) => {
+    e.stopPropagation();
+    if (onUserClick) {
+      onUserClick(userId);
+      alert(userId);
+    }
+  };
+
+  return (
+    <Container
+      maxWidth='md'
+      onClick={() => handleFeedClick(id)}
+      style={{
+        padding: '34px 40px',
+        flexShrink: '0',
+        backgroundColor: 'var(-adaptive50)',
+        border: '1px solid var(--adaptive200)',
+        borderRadius: '0.75rem',
+        boxShadow: '0px 4px 4px 0px var(--adaptiveOpacity100)',
+      }}
+    >
+      <Flex
+        justifyContent='space-between'
+        alignItems='flex-start'
+      >
+        <div
+          onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+            handleUserClick(userId, e);
+          }}
+        >
+          <Image
+            src={profileImage}
+            width={3.5}
+            height={3.5}
+            mode='contain'
+            alt='user profile image'
+          ></Image>
+        </div>
+
+        <Flex
+          direction='column'
+          style={{
+            marginLeft: '1rem',
+            width: '43rem',
+          }}
+        >
+          <Text
+            size='lg'
+            weight={600}
+            style={{ marginTop: '0.2rem', marginBottom: '1rem' }}
+          >
+            {userName}
+          </Text>
+          <Text
+            color='--adaptive500'
+            style={{ marginBottom: '0.5rem' }}
+          >
+            {date}
+          </Text>
+          <Text height={175}>{content}</Text>
+          {imageUrl && (
+            <Image
+              src={imageUrl}
+              width='100%'
+              height='auto'
+              mode='contain'
+              alt='content image'
+            ></Image>
+          )}
+          <Divider></Divider>
+          <Flex>
+            <FeedFooterItem
+              iconImg={''}
+              title='좋아요'
+              count={likesCount}
+            ></FeedFooterItem>
+            <FeedFooterItem
+              iconImg={''}
+              title='댓글'
+              count={commentsCount}
+            ></FeedFooterItem>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Container>
+  );
+};
+
+export default FeedListItem;

--- a/src/components/feed/FeedListItem.tsx
+++ b/src/components/feed/FeedListItem.tsx
@@ -2,6 +2,7 @@ import Container from '~/components/common/Container';
 import Flex from '~/components/common/Flex';
 import Text from '~/components/common/Text';
 import Image from '~/components/common/Image';
+import Avatar from '~/components/common/Avatar';
 import styled from 'styled-components';
 import FeedFooterItem from './FeedFooterItem';
 
@@ -58,19 +59,13 @@ const FeedListItem = ({
   const handleFeedClick = (feedId: string) => {
     if (onFeedClick) {
       onFeedClick(feedId);
-      alert(feedId);
     }
   };
 
   // 사용자 이미지 클릭 시
-  const handleUserClick = (
-    userId: string,
-    e: React.MouseEvent<HTMLDivElement>
-  ) => {
-    e.stopPropagation();
+  const handleUserClick = () => {
     if (onUserClick) {
       onUserClick(userId);
-      alert(userId);
     }
   };
 
@@ -83,20 +78,14 @@ const FeedListItem = ({
         justifyContent='space-between'
         alignItems='flex-start'
       >
-        <div
-          onClick={(e: React.MouseEvent<HTMLDivElement>) => {
-            handleUserClick(userId, e);
-          }}
-        >
-          <Image
+        <div style={{ flex: '1' }}>
+          <Avatar
             src={profileImage}
-            width={3.5}
-            height={3.5}
-            mode='contain'
-            alt='user profile image'
-          ></Image>
+            size='sm'
+            handleClick={handleUserClick}
+            alt='user image'
+          ></Avatar>
         </div>
-
         <Flex
           direction='column'
           ml={1}

--- a/src/components/feed/FeedListItem.tsx
+++ b/src/components/feed/FeedListItem.tsx
@@ -27,6 +27,19 @@ const Divider = styled.div`
   margin: 1rem 0;
 `;
 
+const FeedItemContainer = styled(Container)`
+  padding: 34px 40px;
+  flex-shrink: 0;
+  background-color: var(-adaptive50);
+  border: 1px solid var(--adaptive200);
+  border-radius: 0.75rem;
+  box-shadow: 0px 4px 4px 0px var(--adaptiveOpacity100);
+  cursor: pointer;
+  &:hover {
+    background-color: var(--adaptive100);
+  }
+`;
+
 const FeedListItem = ({
   id,
   userId,
@@ -62,17 +75,9 @@ const FeedListItem = ({
   };
 
   return (
-    <Container
+    <FeedItemContainer
       maxWidth='md'
       onClick={() => handleFeedClick(id)}
-      style={{
-        padding: '34px 40px',
-        flexShrink: '0',
-        backgroundColor: 'var(-adaptive50)',
-        border: '1px solid var(--adaptive200)',
-        borderRadius: '0.75rem',
-        boxShadow: '0px 4px 4px 0px var(--adaptiveOpacity100)',
-      }}
     >
       <Flex
         justifyContent='space-between'
@@ -137,7 +142,7 @@ const FeedListItem = ({
           </Flex>
         </Flex>
       </Flex>
-    </Container>
+    </FeedItemContainer>
   );
 };
 

--- a/src/components/feed/FeedListItem.tsx
+++ b/src/components/feed/FeedListItem.tsx
@@ -10,7 +10,8 @@ export interface FeedListItemPropTypes {
   userId: string;
   profileImage: string;
   userName: string;
-  date: string;
+  createdAt: string;
+  updatedAt?: string;
   content: string;
   imageUrl?: string;
   likesCount: number;
@@ -31,7 +32,8 @@ const FeedListItem = ({
   userId,
   profileImage,
   userName,
-  date,
+  createdAt,
+  updatedAt,
   content,
   imageUrl,
   likesCount,
@@ -108,7 +110,7 @@ const FeedListItem = ({
             color='--adaptive500'
             style={{ marginBottom: '0.5rem' }}
           >
-            {date}
+            {updatedAt ? `${updatedAt} · 수정됨` : createdAt}
           </Text>
           <Text height={175}>{content}</Text>
           {imageUrl && (

--- a/src/components/feed/FeedListItem.tsx
+++ b/src/components/feed/FeedListItem.tsx
@@ -92,8 +92,8 @@ const FeedListItem = ({
 
         <Flex
           direction='column'
+          ml={1}
           style={{
-            marginLeft: '1rem',
             width: '43rem',
           }}
         >

--- a/src/components/feed/FeedListItem.tsx
+++ b/src/components/feed/FeedListItem.tsx
@@ -123,12 +123,12 @@ const FeedListItem = ({
           <Divider></Divider>
           <Flex>
             <FeedFooterItem
-              iconImg={''}
+              iconType={'like'}
               title='좋아요'
               count={likesCount}
             ></FeedFooterItem>
             <FeedFooterItem
-              iconImg={''}
+              iconType={''}
               title='댓글'
               count={commentsCount}
             ></FeedFooterItem>

--- a/src/components/feed/FeedListItem.tsx
+++ b/src/components/feed/FeedListItem.tsx
@@ -5,7 +5,7 @@ import Image from '~/components/common/Image';
 import styled from 'styled-components';
 import FeedFooterItem from './FeedFooterItem';
 
-export interface FeedListItemPropTypes {
+export interface FeedListItemPropsType {
   id: string;
   userId: string;
   profileImage: string;
@@ -40,7 +40,7 @@ const FeedListItem = ({
   commentsCount,
   onFeedClick,
   onUserClick,
-}: FeedListItemPropTypes) => {
+}: FeedListItemPropsType) => {
   // 피드 클릭 시
   const handleFeedClick = (feedId: string) => {
     if (onFeedClick) {

--- a/src/stories/components/FeedFooterItem.stories.tsx
+++ b/src/stories/components/FeedFooterItem.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'Component/FeedFooterItem',
   component: FeedFooterItem,
   argTypes: {
-    iconImg: {
+    iconType: {
       type: { name: 'string' },
       control: {
         type: 'text',
@@ -31,7 +31,7 @@ export const Default = (args: FeedFooterItemPropTypes) => {
 };
 
 Default.args = {
-  iconImg: '',
+  iconType: 'like',
   title: '좋아요',
   count: 34,
 };

--- a/src/stories/components/FeedFooterItem.stories.tsx
+++ b/src/stories/components/FeedFooterItem.stories.tsx
@@ -1,0 +1,37 @@
+import FeedFooterItem, {
+  FeedFooterItemPropTypes,
+} from '~/components/feed/FeedFooterItem';
+
+export default {
+  title: 'Component/FeedFooterItem',
+  component: FeedFooterItem,
+  argTypes: {
+    iconImg: {
+      type: { name: 'string' },
+      control: {
+        type: 'text',
+      },
+    },
+    title: {
+      type: { name: 'string' },
+      control: {
+        type: 'text',
+      },
+    },
+    count: {
+      control: {
+        type: 'number',
+      },
+    },
+  },
+};
+
+export const Default = (args: FeedFooterItemPropTypes) => {
+  return <FeedFooterItem {...args}></FeedFooterItem>;
+};
+
+Default.args = {
+  iconImg: '',
+  title: '좋아요',
+  count: 34,
+};

--- a/src/stories/components/FeedListItem.stories.tsx
+++ b/src/stories/components/FeedListItem.stories.tsx
@@ -1,5 +1,5 @@
 import FeedListItem, {
-  FeedListItemPropTypes,
+  FeedListItemPropsType,
 } from '~/components/feed/FeedListItem';
 
 export default {
@@ -64,7 +64,7 @@ export default {
   },
 };
 
-export const Default = (args: FeedListItemPropTypes) => {
+export const Default = (args: FeedListItemPropsType) => {
   return <FeedListItem {...args}></FeedListItem>;
 };
 

--- a/src/stories/components/FeedListItem.stories.tsx
+++ b/src/stories/components/FeedListItem.stories.tsx
@@ -25,7 +25,13 @@ export default {
         type: 'text',
       },
     },
-    date: {
+    createdAt: {
+      type: { name: 'string' },
+      control: {
+        type: 'text',
+      },
+    },
+    updatedAt: {
       type: { name: 'string' },
       control: {
         type: 'text',
@@ -67,7 +73,8 @@ Default.args = {
   userId: '123',
   profileImage: 'https://picsum.photos/200',
   userName: '주니모',
-  date: '2024년 1월 4일 오후 10시 26분',
+  createdAt: '2024년 1월 4일 오후 10시 26분',
+  updatedAt: '2024년 1월 7일 오후 7시 04분',
   content: '다그닥 다그닥',
   imageUrl: 'https://picsum.photos/400/200',
   likesCount: 23,

--- a/src/stories/components/FeedListItem.stories.tsx
+++ b/src/stories/components/FeedListItem.stories.tsx
@@ -1,0 +1,75 @@
+import FeedListItem, {
+  FeedListItemPropTypes,
+} from '~/components/feed/FeedListItem';
+
+export default {
+  title: 'Component/FeedListItem',
+  component: FeedListItem,
+  argTypes: {
+    id: {
+      type: { name: 'string' },
+    },
+    userId: {
+      type: { name: 'string' },
+    },
+    profileImage: {
+      type: { name: 'string' },
+      control: {
+        type: 'text',
+      },
+    },
+
+    userName: {
+      type: { name: 'string' },
+      control: {
+        type: 'text',
+      },
+    },
+    date: {
+      type: { name: 'string' },
+      control: {
+        type: 'text',
+      },
+    },
+    content: {
+      type: { name: 'string' },
+      control: {
+        type: 'text',
+      },
+    },
+    imageUrl: {
+      type: { name: 'string' },
+      control: {
+        type: 'text',
+      },
+    },
+    likesCount: {
+      type: { name: 'number' },
+      control: {
+        type: 'number',
+      },
+    },
+    commentsCount: {
+      type: { name: 'number' },
+      control: {
+        type: 'number',
+      },
+    },
+  },
+};
+
+export const Default = (args: FeedListItemPropTypes) => {
+  return <FeedListItem {...args}></FeedListItem>;
+};
+
+Default.args = {
+  id: '1',
+  userId: '123',
+  profileImage: 'https://picsum.photos/200',
+  userName: '주니모',
+  date: '2024년 1월 4일 오후 10시 26분',
+  content: '다그닥 다그닥',
+  imageUrl: 'https://picsum.photos/400/200',
+  likesCount: 23,
+  commentsCount: 12,
+};


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- 피드의 List Item 컴포넌트를 구현했습니다. 
- 사용자 사진 클릭 시 props로 받아온 `onUserClick`을 호출합니다. 
- 피드 클릭 시 props로 받아온 `onFeedClick`을 호출합니다. 

## :pushpin: 스크린샷
<img width="1091" alt="스크린샷 2024-01-05 오전 3 54 13" src="https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/62047243/36380225-0b3f-46c5-a227-a69de54719bb">

## :white_check_mark: 고민 중인 부분 및 참고사항

- [ ] 좋아요 수와 댓글 수 아이콘
- [ ] props로 받아오는 것들을 한번씩 검토해주시면 좋겠습니다. 
- [ ] 사용자 프로필 이미지를 Image -> Avatar로 변경할 예정입니다.

<!-- ## 이슈 번호 close -->
Closes #70 