### PR TITLE
[69] Modal 컴포넌트 구현

### DIFF
--- a/src/components/common/Modal/ModalBody.tsx
+++ b/src/components/common/Modal/ModalBody.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface ModalBodyPropsType {
+  children: ReactNode;
+}
+const ModalBody = ({ children }: ModalBodyPropsType) => {
+  return <BodyWrapper>{children}</BodyWrapper>;
+};
+
+export default ModalBody;
+
+const BodyWrapper = styled.div`
+  flex-grow: 1;
+
+  width: 100%;
+  height: 100%;
+  padding: 1.5rem;
+
+  box-sizing: border-box;
+`;

--- a/src/components/common/Modal/ModalHeader.tsx
+++ b/src/components/common/Modal/ModalHeader.tsx
@@ -1,14 +1,14 @@
-import Flex from '../Flex';
-import Text from '../Text';
+import { ReactNode } from 'react';
 import { IconX } from '@tabler/icons-react';
 import styled from 'styled-components';
-import Button from '../Button';
+import Flex from '~/components/common/Flex';
+import Button from '~/components/common/Button';
 
 interface ModalHeaderProps {
-  text: string;
+  children: ReactNode;
   handleClose: () => void;
 }
-const ModalHeader = ({ text, handleClose }: ModalHeaderProps) => {
+const ModalHeader = ({ children, handleClose }: ModalHeaderProps) => {
   return (
     <StyledFlex
       justifyContent='space-between'
@@ -16,12 +16,7 @@ const ModalHeader = ({ text, handleClose }: ModalHeaderProps) => {
       pb={0.375}
     >
       <div></div>
-      <Text
-        size='xl'
-        weight={600}
-      >
-        {text}
-      </Text>
+      {children}
       <Button
         variant='text'
         size='md'
@@ -44,7 +39,7 @@ export default ModalHeader;
 
 const StyledFlex = styled(Flex)`
   width: 100%;
-  border-bottom: 0.1875rem solid var(--adaptive200);
+  border-bottom: 0.125rem solid var(--adaptive200);
 
   box-sizing: border-box;
 `;

--- a/src/components/common/Modal/ModalHeader.tsx
+++ b/src/components/common/Modal/ModalHeader.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Flex from '../Flex';
+import Text from '../Text';
+import { IconX } from '@tabler/icons-react';
+import styled from 'styled-components';
+import Button from '../Button';
+
+interface ModalHeaderProps {
+  text: string;
+  handleClose: () => void;
+}
+const ModalHeader = ({ text, handleClose }: ModalHeaderProps) => {
+  return (
+    <StyledFlex
+      justifyContent='space-between'
+      alignItems='center'
+      pb={0.375}
+    >
+      <div></div>
+      <Text
+        size='xl'
+        weight={600}
+      >
+        {text}
+      </Text>
+      <Button
+        variant='text'
+        size='md'
+        color='--adaptive500'
+        onClick={handleClose}
+        style={{
+          width: '2.5rem',
+          height: '2.5rem',
+          borderRadius: '50%',
+          padding: '0.125rem',
+        }}
+      >
+        <IconX />
+      </Button>
+    </StyledFlex>
+  );
+};
+
+export default ModalHeader;
+
+const StyledFlex = styled(Flex)`
+  margin-bottom: 1rem;
+  border-bottom: 0.1875rem solid var(--adaptive200);
+`;

--- a/src/components/common/Modal/ModalHeader.tsx
+++ b/src/components/common/Modal/ModalHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Flex from '../Flex';
 import Text from '../Text';
 import { IconX } from '@tabler/icons-react';
@@ -44,6 +43,8 @@ const ModalHeader = ({ text, handleClose }: ModalHeaderProps) => {
 export default ModalHeader;
 
 const StyledFlex = styled(Flex)`
-  margin-bottom: 1rem;
+  width: 100%;
   border-bottom: 0.1875rem solid var(--adaptive200);
+
+  box-sizing: border-box;
 `;

--- a/src/components/common/Modal/ModalPage.tsx
+++ b/src/components/common/Modal/ModalPage.tsx
@@ -1,10 +1,21 @@
 import { ReactNode } from 'react';
+import styled from 'styled-components';
 
 interface ModalPagePropsType {
   children: ReactNode;
 }
 const ModalPage = ({ children }: ModalPagePropsType) => {
-  return <>{children}</>;
+  return <PageWrapper>{children}</PageWrapper>;
 };
 
 export default ModalPage;
+
+const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+  height: 100%;
+
+  box-sizing: border-box;
+`;

--- a/src/components/common/Modal/ModalPage.tsx
+++ b/src/components/common/Modal/ModalPage.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+interface ModalPagePropsType {
+  children: ReactNode;
+}
+const ModalPage = ({ children }: ModalPagePropsType) => {
+  return <>{children}</>;
+};
+
+export default ModalPage;

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -5,15 +5,12 @@ import styled from 'styled-components';
 import ModalHeader from './ModalHeader';
 import ModalPage from './ModalPage';
 import ModalBody from './ModalBody';
-
-type ModalVariantType = 'simple' | 'full';
 export interface ModalPropsType {
   visible: boolean;
   handleClose: () => void;
   children: ReactNode;
-  variant: ModalVariantType;
 }
-const Modal = ({ children, visible, handleClose, variant }: ModalPropsType) => {
+const Modal = ({ children, visible, handleClose }: ModalPropsType) => {
   const $overlay = useMemo(() => document.createElement('div'), []);
   const $backdrop = useMemo(() => document.createElement('div'), []);
   useEffect(() => {
@@ -35,10 +32,8 @@ const Modal = ({ children, visible, handleClose, variant }: ModalPropsType) => {
       {visible &&
         ReactDOM.createPortal(
           <ModalContainer
-            variant={variant}
             maxWidth='sm'
-            p={variant === 'simple' ? 1 : 0.1}
-            py={variant === 'simple' ? undefined : 0.375}
+            p={1}
           >
             {children}
           </ModalContainer>,
@@ -64,15 +59,14 @@ const BackgroundDim = styled.div`
   background-color: var(--adaptiveOpacity100);
 `;
 
-const ModalContainer = styled(Container)<{ variant: ModalVariantType }>`
+const ModalContainer = styled(Container)`
   position: fixed;
   top: 50%;
   left: 50%;
   z-index: 100;
 
-  height: ${({ variant }) => (variant === 'simple' ? '15.625rem' : undefined)};
-  min-height: 15.625rem;
-  max-height: ${({ variant }) => (variant === 'full' ? '550px' : undefined)};
+  /* min-height: 15.625rem; */
+  max-height: 37.5rem;
   border-radius: 0.5rem;
   box-shadow: 0 0.1875rem 0.375rem var(--adaptive300);
 

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -1,0 +1,76 @@
+import { ReactNode, useEffect, useMemo } from 'react';
+import ReactDOM from 'react-dom';
+import Container from '../Container';
+import styled from 'styled-components';
+import ModalHeader from './ModalHeader';
+import ModalPage from './ModalPage';
+
+export interface ModalPropsType {
+  visible: boolean;
+  handleClose: () => void;
+  children: ReactNode;
+  type: 'simple' | 'full';
+}
+const Modal = ({ children, visible, handleClose, type }: ModalPropsType) => {
+  const $overlay = useMemo(() => document.createElement('div'), []);
+  const $backdrop = useMemo(() => document.createElement('div'), []);
+  useEffect(() => {
+    document.body.appendChild($overlay);
+    document.body.appendChild($backdrop);
+    return () => {
+      document.body.removeChild($overlay);
+      document.body.removeChild($backdrop);
+    };
+  }, [$overlay, $backdrop]);
+
+  return (
+    <>
+      {visible &&
+        ReactDOM.createPortal(
+          <BackgroundDim onClick={handleClose}></BackgroundDim>,
+          $backdrop
+        )}
+      {visible &&
+        ReactDOM.createPortal(
+          <ModalContainer
+            maxWidth='sm'
+            p={type === 'simple' ? 3 : 0.1}
+            py={type === 'simple' ? undefined : 0.375}
+          >
+            {children}
+          </ModalContainer>,
+          $overlay
+        )}
+    </>
+  );
+};
+Modal.Page = ModalPage;
+Modal.Header = ModalHeader;
+// Modal.Body = ModalBody;
+export default Modal;
+
+const BackgroundDim = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 90;
+
+  width: 100vw;
+  height: 100vh;
+
+  background-color: var(--adaptiveOpacity100);
+`;
+
+const ModalContainer = styled(Container)`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 100;
+
+  height: 15.625rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.1875rem 0.375rem var(--adaptive300);
+
+  box-sizing: border-box;
+  transform: translate(-50%, -50%);
+`;

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -4,14 +4,16 @@ import Container from '../Container';
 import styled from 'styled-components';
 import ModalHeader from './ModalHeader';
 import ModalPage from './ModalPage';
+import ModalBody from './ModalBody';
 
+type ModalVariantType = 'simple' | 'full';
 export interface ModalPropsType {
   visible: boolean;
   handleClose: () => void;
   children: ReactNode;
-  type: 'simple' | 'full';
+  variant: ModalVariantType;
 }
-const Modal = ({ children, visible, handleClose, type }: ModalPropsType) => {
+const Modal = ({ children, visible, handleClose, variant }: ModalPropsType) => {
   const $overlay = useMemo(() => document.createElement('div'), []);
   const $backdrop = useMemo(() => document.createElement('div'), []);
   useEffect(() => {
@@ -33,9 +35,10 @@ const Modal = ({ children, visible, handleClose, type }: ModalPropsType) => {
       {visible &&
         ReactDOM.createPortal(
           <ModalContainer
+            variant={variant}
             maxWidth='sm'
-            p={type === 'simple' ? 3 : 0.1}
-            py={type === 'simple' ? undefined : 0.375}
+            p={variant === 'simple' ? 1 : 0.1}
+            py={variant === 'simple' ? undefined : 0.375}
           >
             {children}
           </ModalContainer>,
@@ -46,7 +49,7 @@ const Modal = ({ children, visible, handleClose, type }: ModalPropsType) => {
 };
 Modal.Page = ModalPage;
 Modal.Header = ModalHeader;
-// Modal.Body = ModalBody;
+Modal.Body = ModalBody;
 export default Modal;
 
 const BackgroundDim = styled.div`
@@ -61,13 +64,14 @@ const BackgroundDim = styled.div`
   background-color: var(--adaptiveOpacity100);
 `;
 
-const ModalContainer = styled(Container)`
+const ModalContainer = styled(Container)<{ variant: ModalVariantType }>`
   position: fixed;
   top: 50%;
   left: 50%;
   z-index: 100;
 
-  height: 15.625rem;
+  height: ${({ variant }) => (variant === 'simple' ? '15.625rem' : undefined)};
+  min-height: 15.625rem;
   border-radius: 0.5rem;
   box-shadow: 0 0.1875rem 0.375rem var(--adaptive300);
 

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -72,9 +72,11 @@ const ModalContainer = styled(Container)<{ variant: ModalVariantType }>`
 
   height: ${({ variant }) => (variant === 'simple' ? '15.625rem' : undefined)};
   min-height: 15.625rem;
+  max-height: ${({ variant }) => (variant === 'full' ? '550px' : undefined)};
   border-radius: 0.5rem;
   box-shadow: 0 0.1875rem 0.375rem var(--adaptive300);
 
   box-sizing: border-box;
+  overflow-y: auto;
   transform: translate(-50%, -50%);
 `;

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -51,6 +51,31 @@ export const ModalWithHeader = () => {
           Etiam ac finibus orci. Vivamus commodo tellus mi, dapibus ultrices
           enim suscipit at. Ut nec dolor quis sem accumsan tincidunt. Quisque
           finibus sapien odio, non porttitor diam aliquam non. Maecenas et nunc
+          vel nisi tempor iaculis id id sapien. Quisque et libero sapien. Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+          lobortis sodales luctus. Duis arcu ipsum, imperdiet sed massa vitae,
+          suscipit scelerisque odio. Pellentesque vel pretium mi. Mauris vel dui
+          lacus. Suspendisse laoreet ultricies eros, a feugiat sem vulputate ut.
+          Proin aliquam, mi ullamcorper dapibus condimentum, mi purus pulvinar
+          velit, ut convallis mauris eros at velit. Vivamus volutpat suscipit
+          viverra. Mauris ultrices, elit at viverra pulvinar, neque urna
+          vulputate turpis, quis egestas massa elit ac augue. Duis at tortor
+          odio. Fusce ut nulla orci. Etiam ac finibus orci. Vivamus commodo
+          tellus mi, dapibus ultrices enim suscipit at. Ut nec dolor quis sem
+          accumsan tincidunt. Quisque finibus sapien odio, non porttitor diam
+          aliquam non. Maecenas et nunc vel nisi tempor iaculis id id sapien.
+          Quisque et libero sapien. Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit. Pellentesque lobortis sodales luctus. Duis arcu
+          ipsum, imperdiet sed massa vitae, suscipit scelerisque odio.
+          Pellentesque vel pretium mi. Mauris vel dui lacus. Suspendisse laoreet
+          ultricies eros, a feugiat sem vulputate ut. Proin aliquam, mi
+          ullamcorper dapibus condimentum, mi purus pulvinar velit, ut convallis
+          mauris eros at velit. Vivamus volutpat suscipit viverra. Mauris
+          ultrices, elit at viverra pulvinar, neque urna vulputate turpis, quis
+          egestas massa elit ac augue. Duis at tortor odio. Fusce ut nulla orci.
+          Etiam ac finibus orci. Vivamus commodo tellus mi, dapibus ultrices
+          enim suscipit at. Ut nec dolor quis sem accumsan tincidunt. Quisque
+          finibus sapien odio, non porttitor diam aliquam non. Maecenas et nunc
           vel nisi tempor iaculis id id sapien. Quisque et libero sapien.
         </Modal.Body>
       </Modal.Page>

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { IconUfo } from '@tabler/icons-react';
+import Modal from '~/components/common/Modal';
+import Flex from '~/components/common/Flex';
+import Text from '~/components/common/Text';
+import Button from '~/components/common/Button';
+import styled from 'styled-components';
+
+export default {
+  title: 'Component/Modal',
+  component: Modal,
+  argTypes: {},
+  args: {},
+};
+
+export const ModalWithHeader = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Modal
+      type={'full'}
+      visible={isOpen}
+      handleClose={() => setIsOpen(false)}
+    >
+      <Modal.Page>
+        <Modal.Header
+          text='기본 모달'
+          handleClose={() => setIsOpen(false)}
+        />
+        <IconUfo stroke={4} />
+      </Modal.Page>
+    </Modal>
+  );
+};
+export const Default = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Modal
+      type='simple'
+      visible={isOpen}
+      handleClose={() => setIsOpen(false)}
+    >
+      <Modal.Page>
+        <StyledFlex
+          direction='column'
+          alignItems='center'
+          justifyContent='space-between'
+        >
+          <Text
+            size='xl'
+            weight={600}
+          >
+            기본 모달입니다
+          </Text>
+          <Button
+            variant='filled'
+            size='md'
+            color='--primaryColor'
+            style={{ width: '100%', padding: '0.75rem' }}
+            onClick={() => setIsOpen(false)}
+          >
+            확인
+          </Button>
+        </StyledFlex>
+      </Modal.Page>
+    </Modal>
+  );
+};
+const StyledFlex = styled(Flex)`
+  width: 100%;
+  height: 100%;
+  margin-bottom: 1rem;
+`;

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { IconUfo } from '@tabler/icons-react';
 import Modal from '~/components/common/Modal';
 import Flex from '~/components/common/Flex';
 import Text from '~/components/common/Text';
@@ -17,7 +16,7 @@ export const ModalWithHeader = () => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Modal
-      type={'full'}
+      variant={'full'}
       visible={isOpen}
       handleClose={() => setIsOpen(false)}
     >
@@ -26,7 +25,34 @@ export const ModalWithHeader = () => {
           text='기본 모달'
           handleClose={() => setIsOpen(false)}
         />
-        <IconUfo stroke={4} />
+        {/* <IconUfo stroke={4} /> */}
+        <Modal.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+          lobortis sodales luctus. Duis arcu ipsum, imperdiet sed massa vitae,
+          suscipit scelerisque odio. Pellentesque vel pretium mi. Mauris vel dui
+          lacus. Suspendisse laoreet ultricies eros, a feugiat sem vulputate ut.
+          Proin aliquam, mi ullamcorper dapibus condimentum, mi purus pulvinar
+          velit, ut convallis mauris eros at velit. Vivamus volutpat suscipit
+          viverra. Mauris ultrices, elit at viverra pulvinar, neque urna
+          vulputate turpis, quis egestas massa elit ac augue. Duis at tortor
+          odio. Fusce ut nulla orci. Etiam ac finibus orci. Vivamus commodo
+          tellus mi, dapibus ultrices enim suscipit at. Ut nec dolor quis sem
+          accumsan tincidunt. Quisque finibus sapien odio, non porttitor diam
+          aliquam non. Maecenas et nunc vel nisi tempor iaculis id id sapien.
+          Quisque et libero sapien. Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit. Pellentesque lobortis sodales luctus. Duis arcu
+          ipsum, imperdiet sed massa vitae, suscipit scelerisque odio.
+          Pellentesque vel pretium mi. Mauris vel dui lacus. Suspendisse laoreet
+          ultricies eros, a feugiat sem vulputate ut. Proin aliquam, mi
+          ullamcorper dapibus condimentum, mi purus pulvinar velit, ut convallis
+          mauris eros at velit. Vivamus volutpat suscipit viverra. Mauris
+          ultrices, elit at viverra pulvinar, neque urna vulputate turpis, quis
+          egestas massa elit ac augue. Duis at tortor odio. Fusce ut nulla orci.
+          Etiam ac finibus orci. Vivamus commodo tellus mi, dapibus ultrices
+          enim suscipit at. Ut nec dolor quis sem accumsan tincidunt. Quisque
+          finibus sapien odio, non porttitor diam aliquam non. Maecenas et nunc
+          vel nisi tempor iaculis id id sapien. Quisque et libero sapien.
+        </Modal.Body>
       </Modal.Page>
     </Modal>
   );
@@ -35,32 +61,34 @@ export const Default = () => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Modal
-      type='simple'
+      variant='simple'
       visible={isOpen}
       handleClose={() => setIsOpen(false)}
     >
       <Modal.Page>
-        <StyledFlex
-          direction='column'
-          alignItems='center'
-          justifyContent='space-between'
-        >
-          <Text
-            size='xl'
-            weight={600}
+        <Modal.Body>
+          <StyledFlex
+            direction='column'
+            alignItems='center'
+            justifyContent='space-between'
           >
-            기본 모달입니다
-          </Text>
-          <Button
-            variant='filled'
-            size='md'
-            color='--primaryColor'
-            style={{ width: '100%', padding: '0.75rem' }}
-            onClick={() => setIsOpen(false)}
-          >
-            확인
-          </Button>
-        </StyledFlex>
+            <Text
+              size='xl'
+              weight={600}
+            >
+              기본 모달입니다
+            </Text>
+            <Button
+              variant='filled'
+              size='md'
+              color='--primaryColor'
+              style={{ width: '100%', padding: '0.75rem' }}
+              onClick={() => setIsOpen(false)}
+            >
+              확인
+            </Button>
+          </StyledFlex>
+        </Modal.Body>
       </Modal.Page>
     </Modal>
   );
@@ -68,5 +96,4 @@ export const Default = () => {
 const StyledFlex = styled(Flex)`
   width: 100%;
   height: 100%;
-  margin-bottom: 1rem;
 `;

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -9,22 +9,24 @@ export default {
   title: 'Component/Modal',
   component: Modal,
   argTypes: {},
-  args: {},
 };
 
 export const ModalWithHeader = () => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Modal
-      variant={'full'}
       visible={isOpen}
       handleClose={() => setIsOpen(false)}
     >
       <Modal.Page>
-        <Modal.Header
-          text='기본 모달'
-          handleClose={() => setIsOpen(false)}
-        />
+        <Modal.Header handleClose={() => setIsOpen(false)}>
+          <Text
+            weight={600}
+            size='lg'
+          >
+            제목
+          </Text>
+        </Modal.Header>
         {/* <IconUfo stroke={4} /> */}
         <Modal.Body>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
@@ -86,7 +88,6 @@ export const Default = () => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Modal
-      variant='simple'
       visible={isOpen}
       handleClose={() => setIsOpen(false)}
     >
@@ -96,6 +97,7 @@ export const Default = () => {
             direction='column'
             alignItems='center'
             justifyContent='space-between'
+            style={{ height: '100px' }}
           >
             <Text
               size='xl'


### PR DESCRIPTION
## :rocket: 주요 작업 내용
Modal 컴포넌트를 구현했습니다
현재 구현 스펙에는 ContextAPI를 활용한 Modal Page 구성이 제외되었습니다. (추후 새로운 Issue로 추가할 예정입니다)
## :pushpin: 스크린샷
![modal-simple](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/88219703/3f765a9f-795f-4dac-b070-fe50bb6e2eb6)

![modal-full](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/88219703/6a518320-c9ab-42cb-bbb1-b308de15260d)

## :white_check_mark: 고민 중인 부분 및 참고사항
Compound Component 아키텍처로 구성했습니다
Modal > Modal.Page > Modal.Header | Modal.Body 로 포함관계 (부모관계)를 나타낼 수 있습니다
- variant props로 simple(header 없음, 높이 고정), full(header 있음, 가변 높이)를 선택할 수 있습니다
- Modal.Body, Modal.Page는 padding 스타일을 적용하며 이후 ContextAPI를 활용할 때 활용될 예정입니다. 
   - Modal의 실제 content는 Modal.Body에 넣으시고, Modal.Page로 wrap한다고 생각하시면 됩니다
- Modal 크기는 하나만 지원합니다. 
- [ ] Modal UI 및 로직에서 빠진 부분 있으면 피드백 부탁드립니다
- [ ] 현재 모달 사용 방식이 많이 복잡하다고 생각합니다. 너무 복잡한 것 같으면 의견 얘기해주세요
Closes #69 