### PR TITLE
[74] 로그인 페이지의 Template에서 Login Form 컴포넌트 구현

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -15,7 +15,9 @@ export interface InputPropsType {
   message?: string;
   messageColor?: ColorType;
   onBlur?: (text: string) => boolean;
-  onChange: (text: string, InputName?: string) => void;
+  onChange:
+    | ((text: string, InputName: string) => void)
+    | ((text: string) => void);
   children?: React.ReactNode;
   InputName?: string;
 }

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -70,7 +70,7 @@ const Input = ({
 }: InputPropsType) => {
   const [isError, setIsError] = useState(false);
   const ref = useRef<HTMLInputElement | null>(null);
-  let timer: ReturnType<typeof setTimeout>;
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const labelFontSize = 'sm' as FontSizeType;
   const inputFontSize = 'lg' as FontSizeType;
@@ -98,10 +98,10 @@ const Input = ({
   };
 
   const debouncing = (inputValue: string, name: string) => {
-    if (timer) {
-      clearTimeout(timer);
+    if (timer.current) {
+      clearTimeout(timer.current);
     }
-    timer = setTimeout(() => {
+    timer.current = setTimeout(() => {
       if (onChange !== undefined) {
         onChange(inputValue, name);
       }

--- a/src/components/loginForm/LoginForm.tsx
+++ b/src/components/loginForm/LoginForm.tsx
@@ -55,10 +55,7 @@ const LoginForm = () => {
             InputName='password'
             type='password'
           />
-          <Container
-            maxWidth='md'
-            style={{ width: 'fit-content' }}
-          >
+          <Container maxWidth='sm'>
             <Flex
               direction='column'
               gap={1}

--- a/src/components/loginForm/LoginForm.tsx
+++ b/src/components/loginForm/LoginForm.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import Button from '../common/Button';
+import Container from '../common/Container';
+import Flex from '../common/Flex';
+import Input from '../input/Input';
+import Text from '../common/Text';
+
+const LoginForm = () => {
+  const [userLoginInfo, setUserLoginInfo] = useState({
+    email: '',
+    password: '',
+  });
+
+  const onChange = (text: string, InputName: string) => {
+    setUserLoginInfo({ ...userLoginInfo, [InputName]: text });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    alert('onSubmit');
+  };
+
+  const onClick = () => {
+    alert('onClick');
+  };
+
+  const onBlur = (text: string) => text === 'example';
+
+  return (
+    <Container maxWidth='md'>
+      <form onSubmit={onSubmit}>
+        <Flex direction='column'>
+          <Container maxWidth='sm'>
+            <Text
+              size='lg'
+              color='--adaptive900'
+            >
+              로그인
+            </Text>
+          </Container>
+          <Input
+            label='이메일'
+            type='email'
+            placeholder='example@gmail.com'
+            message='올바르지 않은 이메일 형식이에요'
+            messageColor='--red600'
+            onChange={onChange}
+            onBlur={onBlur}
+            InputName='email'
+          />
+          <Input
+            label='비밀번호'
+            placeholder='비밀번호를 입력해주세요'
+            onChange={onChange}
+            InputName='password'
+            type='password'
+          />
+          <Container
+            maxWidth='md'
+            style={{ width: 'fit-content' }}
+          >
+            <Flex
+              direction='column'
+              gap={1}
+            >
+              <Button
+                size='lg'
+                variant='filled'
+                color='--primaryColor'
+                type='submit'
+              >
+                로그인
+              </Button>
+              <Button
+                size='lg'
+                variant='outlined'
+                color='--primaryColor'
+                type='button'
+                onClick={onClick}
+              >
+                가입하기
+              </Button>
+            </Flex>
+          </Container>
+        </Flex>
+      </form>
+    </Container>
+  );
+};
+
+export default LoginForm;

--- a/src/stories/components/Login.stories.tsx
+++ b/src/stories/components/Login.stories.tsx
@@ -1,0 +1,13 @@
+import LoginForm from '~/components/loginForm/LoginForm';
+
+export default {
+  title: 'Component/LoginForm',
+  component: LoginForm,
+  tags: ['autodocs'],
+  argTypes: {},
+  args: {},
+};
+
+export const Standard = () => {
+  return <LoginForm />;
+};


### PR DESCRIPTION
## :rocket: 주요 작업 내용
1. 로그인 페이지의 Template에서 Login Form 컴포넌트를 구현했습니다.

## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86847564/52f6e5b4-73bd-4a22-a9bb-8012757d1400)

## :white_check_mark: 고민 중인 부분 및 참고사항
- [ ] 버튼 크기와 input 필드의 길이 조절이 필요할 것 같습니다.

<!-- ## 이슈 번호 close -->
close #74 
