### PR TITLE
[107] 잘못 마이그레이션된 emotion 공통 로직 수정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,5 +15,12 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
+    'no-restricted-imports': [
+      'warn',
+      {
+        name: 'styled-components',
+        message: "\n'@emotion/styled'를 사용해주세요.",
+      },
+    ],
   },
 };

--- a/src/components/RadioGroup/Radio.tsx
+++ b/src/components/RadioGroup/Radio.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import Flex from '~/components/common/Flex';
 import Text from '~/components/common/Text';
 

--- a/src/components/common/Box.tsx
+++ b/src/components/common/Box.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import { CommonStyle, CommonStylePropsType } from './CommonStyle';
 
 export interface BoxPropsType extends CommonStylePropsType {}

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -13,10 +13,9 @@ export interface ButtonPropsType extends CommonStylePropsType {
   rightItem?: ReactNode;
 }
 
-const StyledButton = styled.button(
-  (props: ButtonPropsType) => `
+const StyledButton = styled.button<ButtonPropsType>`
   ${CommonStyle}
-  
+
   display: flex;
   align-items: center;
   justify-content: center;
@@ -25,22 +24,17 @@ const StyledButton = styled.button(
   border: 0.125rem solid;
   border-radius: 0.25rem;
 
-  background-color: ${
-    props.variant === 'filled' ? `var(${props.color})` : 'var(--transparent)'
-  };
+  background-color: ${({ variant, color }) =>
+    variant === 'filled' ? `var(${color})` : 'var(--transparent)'};
 
-  color: ${props.variant === 'filled' ? 'var(--white)' : `var(${props.color})`};
+  color: ${({ variant, color }) =>
+    variant === 'filled' ? 'var(--white)' : `var(${color})`};
   font-weight: 600;
-  font-size: ${
-    FONT_SIZE[
-      FONT_SIZE_UNIT.find((_, i, arr) => arr[i + 1] === props.size) ??
-        props.size
-    ]
-  };
+  font-size: ${({ size }) =>
+    FONT_SIZE[FONT_SIZE_UNIT.find((_, i, arr) => arr[i + 1] === size) ?? size]};
 
-  border-color: ${
-    props.variant === 'outlined' ? `var(${props.color})` : 'var(--transparent)'
-  };
+  border-color: ${({ variant, color }) =>
+    variant === 'outlined' ? `var(${color})` : 'var(--transparent)'};
 
   box-sizing: border-box;
 
@@ -51,28 +45,24 @@ const StyledButton = styled.button(
   transition-property: filter, background-color;
 
   &:disabled {
-    background-color: ${
-      props.variant === 'filled' ? 'var(--adaptive200)' : 'var(--transparent)'
-    };
+    background-color: ${({ variant }) =>
+      variant === 'filled' ? 'var(--adaptive200)' : 'var(--transparent)'};
 
     color: var(--adaptive400);
 
-    border-color: ${
-      props.variant === 'outlined' ? 'var(--adaptive300)' : 'var(--transparent)'
-    };
+    border-color: ${({ variant }) =>
+      variant === 'outlined' ? 'var(--adaptive300)' : 'var(--transparent)'};
 
     cursor: not-allowed;
   }
 
   &:enabled:hover {
-    ${
-      props.variant === 'filled'
+    ${({ variant }) =>
+      variant === 'filled'
         ? `filter: saturate(0.8);`
-        : `background-color: var(--adaptive200);`
-    }
+        : `background-color: var(--adaptive200);`}
   }
-`
-);
+`;
 
 const Button: React.FC<React.ComponentProps<typeof StyledButton>> = ({
   ...args

--- a/src/components/common/CommonStyle.tsx
+++ b/src/components/common/CommonStyle.tsx
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from '@emotion/react';
 import {
   handleVariable,
   handleValue,
@@ -37,179 +37,146 @@ export interface CommonStylePropsType {
   basis?: number | ResponsiveStyleType<number>;
 }
 
-export const CommonStyle = css<CommonStylePropsType>`
-  flex-basis: ${({ basis }) => handleValue(basis, 'base')};
-  flex-grow: ${({ grow }) => handleValue(grow, 'base')};
-  flex-shrink: ${({ shrink }) => handleValue(shrink, 'base')};
+export const CommonStyle = (props: CommonStylePropsType) => css`
+  flex-basis: ${handleValue(props.basis, 'base')};
+  flex-grow: ${handleValue(props.grow, 'base')};
+  flex-shrink: ${handleValue(props.shrink, 'base')};
 
-  width: ${({ width }) => handleSize(width, 'base')};
-  height: ${({ height }) => handleSize(height, 'base')};
-  min-width: ${({ minWidth }) => handleSize(minWidth, 'base')};
-  min-height: ${({ minHeight }) => handleSize(minHeight, 'base')};
-  max-width: ${({ maxWidth }) => handleSize(maxWidth, 'base')};
-  max-height: ${({ maxHeight }) => handleSize(maxHeight, 'base')};
-  margin: ${({ m }) => handleSize(m, 'base')};
-  margin-top: ${({ my, mt }) =>
-    handleSize(mt, 'base') ?? handleSize(my, 'base')};
-  margin-right: ${({ mx, mr }) =>
-    handleSize(mr, 'base') ?? handleSize(mx, 'base')};
-  margin-bottom: ${({ my, mb }) =>
-    handleSize(mb, 'base') ?? handleSize(my, 'base')};
-  margin-left: ${({ mx, ml }) =>
-    handleSize(ml, 'base') ?? handleSize(mx, 'base')};
-  padding: ${({ p }) => handleSize(p, 'base')};
-  padding-top: ${({ py, pt }) =>
-    handleSize(pt, 'base') ?? handleSize(py, 'base')};
-  padding-right: ${({ px, pr }) =>
-    handleSize(pr, 'base') ?? handleSize(px, 'base')};
-  padding-bottom: ${({ py, pb }) =>
-    handleSize(pb, 'base') ?? handleSize(py, 'base')};
-  padding-left: ${({ px, pl }) =>
-    handleSize(pl, 'base') ?? handleSize(px, 'base')};
+  width: ${handleSize(props.width, 'base')};
+  height: ${handleSize(props.height, 'base')};
+  min-width: ${handleSize(props.minWidth, 'base')};
+  min-height: ${handleSize(props.minHeight, 'base')};
+  max-width: ${handleSize(props.maxWidth, 'base')};
+  max-height: ${handleSize(props.maxHeight, 'base')};
+  margin: ${handleSize(props.m, 'base')};
+  margin-top: ${handleSize(props.mt, 'base') ?? handleSize(props.my, 'base')};
+  margin-right: ${handleSize(props.mr, 'base') ?? handleSize(props.mx, 'base')};
+  margin-bottom: ${handleSize(props.mb, 'base') ??
+  handleSize(props.my, 'base')};
+  margin-left: ${handleSize(props.ml, 'base') ?? handleSize(props.mx, 'base')};
+  padding: ${handleSize(props.p, 'base')};
+  padding-top: ${handleSize(props.pt, 'base') ?? handleSize(props.py, 'base')};
+  padding-right: ${handleSize(props.pr, 'base') ??
+  handleSize(props.px, 'base')};
+  padding-bottom: ${handleSize(props.pb, 'base') ??
+  handleSize(props.py, 'base')};
+  padding-left: ${handleSize(props.pl, 'base') ?? handleSize(props.px, 'base')};
 
-  background-color: ${({ bgColor }) => handleVariable(bgColor, 'base')};
+  background-color: ${handleVariable(props.bgColor, 'base')};
 
-  color: ${({ color }) => handleVariable(color, 'base')};
+  color: ${handleVariable(props.color, 'base')};
 
-  opacity: ${({ opacity }) => handleValue(opacity, 'base')};
+  opacity: ${handleValue(props.opacity, 'base')};
 
   @media screen and (width <= ${CONTAINER_SIZE['sm']}) {
-    flex-basis: ${({ basis }) => handleValue(basis, 'sm')};
-    flex-grow: ${({ grow }) => handleValue(grow, 'sm')};
-    flex-shrink: ${({ shrink }) => handleValue(shrink, 'sm')};
+    flex-basis: ${handleValue(props.basis, 'sm')};
+    flex-grow: ${handleValue(props.grow, 'sm')};
+    flex-shrink: ${handleValue(props.shrink, 'sm')};
 
-    width: ${({ width }) => handleSize(width, 'sm')};
-    height: ${({ height }) => handleSize(height, 'sm')};
-    min-width: ${({ minWidth }) => handleSize(minWidth, 'sm')};
-    min-height: ${({ minHeight }) => handleSize(minHeight, 'sm')};
-    max-width: ${({ maxWidth }) => handleSize(maxWidth, 'sm')};
-    max-height: ${({ maxHeight }) => handleSize(maxHeight, 'sm')};
-    margin-top: ${({ my, mt }) => handleSize(mt, 'sm') ?? handleSize(my, 'sm')};
-    margin-right: ${({ mx, mr }) =>
-      handleSize(mr, 'sm') ?? handleSize(mx, 'sm')};
-    margin-bottom: ${({ my, mb }) =>
-      handleSize(mb, 'sm') ?? handleSize(my, 'sm')};
-    margin-left: ${({ mx, ml }) =>
-      handleSize(ml, 'sm') ?? handleSize(mx, 'sm')};
-    padding: ${({ p }) => handleSize(p, 'sm')};
-    padding-top: ${({ py, pt }) =>
-      handleSize(pt, 'sm') ?? handleSize(py, 'sm')};
-    padding-right: ${({ px, pr }) =>
-      handleSize(pr, 'sm') ?? handleSize(px, 'sm')};
-    padding-bottom: ${({ py, pb }) =>
-      handleSize(pb, 'sm') ?? handleSize(py, 'sm')};
-    padding-left: ${({ px, pl }) =>
-      handleSize(pl, 'sm') ?? handleSize(px, 'sm')};
+    width: ${handleSize(props.width, 'sm')};
+    height: ${handleSize(props.height, 'sm')};
+    min-width: ${handleSize(props.minWidth, 'sm')};
+    min-height: ${handleSize(props.minHeight, 'sm')};
+    max-width: ${handleSize(props.maxWidth, 'sm')};
+    max-height: ${handleSize(props.maxHeight, 'sm')};
+    margin-top: ${handleSize(props.mt, 'sm') ?? handleSize(props.my, 'sm')};
+    margin-right: ${handleSize(props.mr, 'sm') ?? handleSize(props.mx, 'sm')};
+    margin-bottom: ${handleSize(props.mb, 'sm') ?? handleSize(props.my, 'sm')};
+    margin-left: ${handleSize(props.ml, 'sm') ?? handleSize(props.mx, 'sm')};
+    padding: ${handleSize(props.p, 'sm')};
+    padding-top: ${handleSize(props.pt, 'sm') ?? handleSize(props.py, 'sm')};
+    padding-right: ${handleSize(props.pr, 'sm') ?? handleSize(props.px, 'sm')};
+    padding-bottom: ${handleSize(props.pb, 'sm') ?? handleSize(props.py, 'sm')};
+    padding-left: ${handleSize(props.pl, 'sm') ?? handleSize(props.px, 'sm')};
 
-    background-color: ${({ bgColor }) => handleVariable(bgColor, 'sm')};
+    background-color: ${handleVariable(props.bgColor, 'sm')};
 
-    color: ${({ color }) => handleVariable(color, 'sm')};
+    color: ${handleVariable(props.color, 'sm')};
 
-    opacity: ${({ opacity }) => handleValue(opacity, 'sm')};
+    opacity: ${handleValue(props.opacity, 'sm')};
   }
 
   @media screen and (width > ${CONTAINER_SIZE['sm']}) {
-    flex-basis: ${({ basis }) => handleValue(basis, 'md')};
-    flex-grow: ${({ grow }) => handleValue(grow, 'md')};
-    flex-shrink: ${({ shrink }) => handleValue(shrink, 'md')};
+    flex-basis: ${handleValue(props.basis, 'md')};
+    flex-grow: ${handleValue(props.grow, 'md')};
+    flex-shrink: ${handleValue(props.shrink, 'md')};
 
-    width: ${({ width }) => handleSize(width, 'md')};
-    height: ${({ height }) => handleSize(height, 'md')};
-    min-width: ${({ minWidth }) => handleSize(minWidth, 'md')};
-    min-height: ${({ minHeight }) => handleSize(minHeight, 'md')};
-    max-width: ${({ maxWidth }) => handleSize(maxWidth, 'md')};
-    max-height: ${({ maxHeight }) => handleSize(maxHeight, 'md')};
-    margin-top: ${({ my, mt }) => handleSize(mt, 'md') ?? handleSize(my, 'md')};
-    margin-right: ${({ mx, mr }) =>
-      handleSize(mr, 'md') ?? handleSize(mx, 'md')};
-    margin-bottom: ${({ my, mb }) =>
-      handleSize(mb, 'md') ?? handleSize(my, 'md')};
-    margin-left: ${({ mx, ml }) =>
-      handleSize(ml, 'md') ?? handleSize(mx, 'md')};
-    padding: ${({ p }) => handleSize(p, 'md')};
-    padding-top: ${({ py, pt }) =>
-      handleSize(pt, 'md') ?? handleSize(py, 'md')};
-    padding-right: ${({ px, pr }) =>
-      handleSize(pr, 'md') ?? handleSize(px, 'md')};
-    padding-bottom: ${({ py, pb }) =>
-      handleSize(pb, 'md') ?? handleSize(py, 'md')};
-    padding-left: ${({ px, pl }) =>
-      handleSize(pl, 'md') ?? handleSize(px, 'md')};
+    width: ${handleSize(props.width, 'md')};
+    height: ${handleSize(props.height, 'md')};
+    min-width: ${handleSize(props.minWidth, 'md')};
+    min-height: ${handleSize(props.minHeight, 'md')};
+    max-width: ${handleSize(props.maxWidth, 'md')};
+    max-height: ${handleSize(props.maxHeight, 'md')};
+    margin-top: ${handleSize(props.mt, 'md') ?? handleSize(props.my, 'md')};
+    margin-right: ${handleSize(props.mr, 'md') ?? handleSize(props.mx, 'md')};
+    margin-bottom: ${handleSize(props.mb, 'md') ?? handleSize(props.my, 'md')};
+    margin-left: ${handleSize(props.ml, 'md') ?? handleSize(props.mx, 'md')};
+    padding: ${handleSize(props.p, 'md')};
+    padding-top: ${handleSize(props.pt, 'md') ?? handleSize(props.py, 'md')};
+    padding-right: ${handleSize(props.pr, 'md') ?? handleSize(props.px, 'md')};
+    padding-bottom: ${handleSize(props.pb, 'md') ?? handleSize(props.py, 'md')};
+    padding-left: ${handleSize(props.pl, 'md') ?? handleSize(props.px, 'md')};
 
-    background-color: ${({ bgColor }) => handleVariable(bgColor, 'md')};
+    background-color: ${handleVariable(props.bgColor, 'md')};
 
-    color: ${({ color }) => handleVariable(color, 'md')};
+    color: ${handleVariable(props.color, 'md')};
 
-    opacity: ${({ opacity }) => handleValue(opacity, 'md')};
+    opacity: ${handleValue(props.opacity, 'md')};
   }
 
   @media screen and (width > ${CONTAINER_SIZE['md']}) {
-    flex-basis: ${({ basis }) => handleValue(basis, 'lg')};
-    flex-grow: ${({ grow }) => handleValue(grow, 'lg')};
-    flex-shrink: ${({ shrink }) => handleValue(shrink, 'lg')};
+    flex-basis: ${handleValue(props.basis, 'lg')};
+    flex-grow: ${handleValue(props.grow, 'lg')};
+    flex-shrink: ${handleValue(props.shrink, 'lg')};
 
-    width: ${({ width }) => handleSize(width, 'lg')};
-    height: ${({ height }) => handleSize(height, 'lg')};
-    min-width: ${({ minWidth }) => handleSize(minWidth, 'lg')};
-    min-height: ${({ minHeight }) => handleSize(minHeight, 'lg')};
-    max-width: ${({ maxWidth }) => handleSize(maxWidth, 'lg')};
-    max-height: ${({ maxHeight }) => handleSize(maxHeight, 'lg')};
-    margin-top: ${({ my, mt }) => handleSize(mt, 'lg') ?? handleSize(my, 'lg')};
-    margin-right: ${({ mx, mr }) =>
-      handleSize(mr, 'lg') ?? handleSize(mx, 'lg')};
-    margin-bottom: ${({ my, mb }) =>
-      handleSize(mb, 'lg') ?? handleSize(my, 'lg')};
-    margin-left: ${({ mx, ml }) =>
-      handleSize(ml, 'lg') ?? handleSize(mx, 'lg')};
-    padding: ${({ p }) => handleSize(p, 'lg')};
-    padding-top: ${({ py, pt }) =>
-      handleSize(pt, 'lg') ?? handleSize(py, 'lg')};
-    padding-right: ${({ px, pr }) =>
-      handleSize(pr, 'lg') ?? handleSize(px, 'lg')};
-    padding-bottom: ${({ py, pb }) =>
-      handleSize(pb, 'lg') ?? handleSize(py, 'lg')};
-    padding-left: ${({ px, pl }) =>
-      handleSize(pl, 'lg') ?? handleSize(px, 'lg')};
+    width: ${handleSize(props.width, 'lg')};
+    height: ${handleSize(props.height, 'lg')};
+    min-width: ${handleSize(props.minWidth, 'lg')};
+    min-height: ${handleSize(props.minHeight, 'lg')};
+    max-width: ${handleSize(props.maxWidth, 'lg')};
+    max-height: ${handleSize(props.maxHeight, 'lg')};
+    margin-top: ${handleSize(props.mt, 'lg') ?? handleSize(props.my, 'lg')};
+    margin-right: ${handleSize(props.mr, 'lg') ?? handleSize(props.mx, 'lg')};
+    margin-bottom: ${handleSize(props.mb, 'lg') ?? handleSize(props.my, 'lg')};
+    margin-left: ${handleSize(props.ml, 'lg') ?? handleSize(props.mx, 'lg')};
+    padding: ${handleSize(props.p, 'lg')};
+    padding-top: ${handleSize(props.pt, 'lg') ?? handleSize(props.py, 'lg')};
+    padding-right: ${handleSize(props.pr, 'lg') ?? handleSize(props.px, 'lg')};
+    padding-bottom: ${handleSize(props.pb, 'lg') ?? handleSize(props.py, 'lg')};
+    padding-left: ${handleSize(props.pl, 'lg') ?? handleSize(props.px, 'lg')};
 
-    background-color: ${({ bgColor }) => handleVariable(bgColor, 'lg')};
+    background-color: ${handleVariable(props.bgColor, 'lg')};
 
-    color: ${({ color }) => handleVariable(color, 'lg')};
+    color: ${handleVariable(props.color, 'lg')};
 
-    opacity: ${({ opacity }) => handleValue(opacity, 'lg')};
+    opacity: ${handleValue(props.opacity, 'lg')};
   }
 
   @media screen and (width > ${CONTAINER_SIZE['lg']}) {
-    flex-basis: ${({ basis }) => handleValue(basis, 'xl')};
-    flex-grow: ${({ grow }) => handleValue(grow, 'xl')};
-    flex-shrink: ${({ shrink }) => handleValue(shrink, 'xl')};
+    flex-basis: ${handleValue(props.basis, 'xl')};
+    flex-grow: ${handleValue(props.grow, 'xl')};
+    flex-shrink: ${handleValue(props.shrink, 'xl')};
 
-    width: ${({ width }) => handleSize(width, 'xl')};
-    height: ${({ height }) => handleSize(height, 'xl')};
-    min-width: ${({ minWidth }) => handleSize(minWidth, 'xl')};
-    min-height: ${({ minHeight }) => handleSize(minHeight, 'xl')};
-    max-width: ${({ maxWidth }) => handleSize(maxWidth, 'xl')};
-    max-height: ${({ maxHeight }) => handleSize(maxHeight, 'xl')};
-    margin-top: ${({ my, mt }) => handleSize(mt, 'xl') ?? handleSize(my, 'xl')};
-    margin-right: ${({ mx, mr }) =>
-      handleSize(mr, 'xl') ?? handleSize(mx, 'xl')};
-    margin-bottom: ${({ my, mb }) =>
-      handleSize(mb, 'xl') ?? handleSize(my, 'xl')};
-    margin-left: ${({ mx, ml }) =>
-      handleSize(ml, 'xl') ?? handleSize(mx, 'xl')};
-    padding: ${({ p }) => handleSize(p, 'xl')};
-    padding-top: ${({ py, pt }) =>
-      handleSize(pt, 'xl') ?? handleSize(py, 'xl')};
-    padding-right: ${({ px, pr }) =>
-      handleSize(pr, 'xl') ?? handleSize(px, 'xl')};
-    padding-bottom: ${({ py, pb }) =>
-      handleSize(pb, 'xl') ?? handleSize(py, 'xl')};
-    padding-left: ${({ px, pl }) =>
-      handleSize(pl, 'xl') ?? handleSize(px, 'xl')};
+    width: ${handleSize(props.width, 'xl')};
+    height: ${handleSize(props.height, 'xl')};
+    min-width: ${handleSize(props.minWidth, 'xl')};
+    min-height: ${handleSize(props.minHeight, 'xl')};
+    max-width: ${handleSize(props.maxWidth, 'xl')};
+    max-height: ${handleSize(props.maxHeight, 'xl')};
+    margin-top: ${handleSize(props.mt, 'xl') ?? handleSize(props.my, 'xl')};
+    margin-right: ${handleSize(props.mr, 'xl') ?? handleSize(props.mx, 'xl')};
+    margin-bottom: ${handleSize(props.mb, 'xl') ?? handleSize(props.my, 'xl')};
+    margin-left: ${handleSize(props.ml, 'xl') ?? handleSize(props.mx, 'xl')};
+    padding: ${handleSize(props.p, 'xl')};
+    padding-top: ${handleSize(props.pt, 'xl') ?? handleSize(props.py, 'xl')};
+    padding-right: ${handleSize(props.pr, 'xl') ?? handleSize(props.px, 'xl')};
+    padding-bottom: ${handleSize(props.pb, 'xl') ?? handleSize(props.py, 'xl')};
+    padding-left: ${handleSize(props.pl, 'xl') ?? handleSize(props.px, 'xl')};
 
-    background-color: ${({ bgColor }) => handleVariable(bgColor, 'xl')};
+    background-color: ${handleVariable(props.bgColor, 'xl')};
 
-    color: ${({ color }) => handleVariable(color, 'xl')};
+    color: ${handleVariable(props.color, 'xl')};
 
-    opacity: ${({ opacity }) => handleValue(opacity, 'xl')};
+    opacity: ${handleValue(props.opacity, 'xl')};
   }
 `;

--- a/src/components/common/Container.tsx
+++ b/src/components/common/Container.tsx
@@ -7,18 +7,16 @@ export interface ContainerPropsType extends CommonStylePropsType {
   maxWidth: ContainerSizeType;
 }
 
-const Container = styled.div(
-  (props: ContainerPropsType) => `
+const Container = styled.div<ContainerPropsType>`
   ${CommonStyle}
-  
+
   width: 100%;
-  max-width: ${CONTAINER_SIZE[props.maxWidth]};
+  max-width: ${({ maxWidth }) => CONTAINER_SIZE[maxWidth]};
   margin: 0 auto;
 
   background-color: var(--adaptive50);
 
   color: var(--adaptive950);
-`
-);
+`;
 
 export default Container;

--- a/src/components/common/Flex.tsx
+++ b/src/components/common/Flex.tsx
@@ -13,32 +13,20 @@ export interface FlexPropsType extends CommonStylePropsType {
   columnGap?: number;
 }
 
-const Flex = styled.div(
-  (props: FlexPropsType) => `
+const Flex = styled.div<FlexPropsType>`
   ${CommonStyle}
 
   display: flex;
-  flex-direction: ${props.direction};
-  flex-wrap: ${props.wrap};
-  align-content: ${props.alignContent};
-  align-items: ${props.alignItems};
-  justify-content: ${props.justifyContent};
+  flex-direction: ${({ direction }) => direction};
+  flex-wrap: ${({ wrap }) => wrap};
+  align-content: ${({ alignContent }) => alignContent};
+  align-items: ${({ alignItems }) => alignItems};
+  justify-content: ${({ justifyContent }) => justifyContent};
 
-  column-gap: ${
-    props.columnGap
-      ? `${props.columnGap}rem`
-      : props.gap
-        ? `${props.gap}rem`
-        : undefined
-  };
-  row-gap: ${
-    props.rowGap
-      ? `${props.rowGap}rem`
-      : props.gap
-        ? `${props.gap}rem`
-        : undefined
-  };
-`
-);
+  column-gap: ${({ gap, columnGap }) =>
+    columnGap ? `${columnGap}rem` : gap ? `${gap}rem` : undefined};
+  row-gap: ${({ gap, rowGap }) =>
+    rowGap ? `${rowGap}rem` : gap ? `${gap}rem` : undefined};
+`;
 
 export default Flex;

--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -1,7 +1,7 @@
+import styled from '@emotion/styled';
 import LogoNormal from '~/assets/logo-normal.svg';
 import LogoSimple from '~/assets/logo-simple.svg';
 import { LOGO_SIZE } from '~/constants/design';
-import styled from 'styled-components';
 import Image from './Image';
 
 export interface LogoPropsType {

--- a/src/components/common/Modal/ModalBody.tsx
+++ b/src/components/common/Modal/ModalBody.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 
 interface ModalBodyPropsType {
   children: ReactNode;

--- a/src/components/common/Modal/ModalHeader.tsx
+++ b/src/components/common/Modal/ModalHeader.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { IconX } from '@tabler/icons-react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import Flex from '~/components/common/Flex';
 import Button from '~/components/common/Button';
 

--- a/src/components/common/Modal/ModalPage.tsx
+++ b/src/components/common/Modal/ModalPage.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 
 interface ModalPagePropsType {
   children: ReactNode;

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useMemo } from 'react';
 import ReactDOM from 'react-dom';
+import styled from '@emotion/styled';
 import Container from '../Container';
-import styled from 'styled-components';
 import ModalHeader from './ModalHeader';
 import ModalPage from './ModalPage';
 import ModalBody from './ModalBody';

--- a/src/components/common/NavBar/index.tsx
+++ b/src/components/common/NavBar/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import { Link, useNavigate } from 'react-router-dom';
 import Container from '~/components/common/Container';
 import Flex from '~/components/common/Flex';

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -24,82 +24,71 @@ const wave = keyframes`
   }
 `;
 
-const Skeleton = styled.div(
-  ({ width = 10, height = 1, ...props }: SkeletonPropsType) => `
+const Skeleton = styled.div<SkeletonPropsType>`
   ${CommonStyle}
-  
-  display: ${props.inline ? 'inline-block' : 'block'};
 
-  width: ${
-    props.circle
+  display: ${({ inline }) => (inline ? 'inline-block' : 'block')};
+
+  width: ${({ circle, width = 10, height = 1 }) =>
+    circle
       ? `max(${handleSize(width, 'base')}, ${handleSize(height, 'base')})`
-      : handleSize(width, 'base')
-  };
-  height: ${
-    props.circle
+      : handleSize(width, 'base')};
+  height: ${({ circle, width = 10, height = 1 }) =>
+    circle
       ? `max(${handleSize(width, 'base')}, ${handleSize(height, 'base')})`
-      : handleSize(height, 'base')
-  };
-  border-radius: ${props.circle ? '50%' : '0.125rem'};
+      : handleSize(height, 'base')};
+  border-radius: ${({ circle }) => (circle ? '50%' : '0.125rem')};
 
   background-color: var(--adaptive300);
 
   animation: ${wave} 2s infinite linear paused alternate;
 
-  animation-play-state: ${props.animation ? 'running' : 'pasued'};
+  animation-play-state: ${({ animation }) =>
+    animation ? 'running' : 'pasued'};
 
   @media screen and (width <= ${CONTAINER_SIZE['sm']}) {
-    width: ${
-      props.circle
+    width: ${({ circle, width = 10, height = 1 }) =>
+      circle
         ? `max(${handleSize(width, 'sm')}, ${handleSize(height, 'sm')})`
-        : handleSize(width, 'sm')
-    };
-    height: ${
-      props.circle
+        : handleSize(width, 'sm')};
+    height: ${({ circle, width = 10, height = 1 }) =>
+      circle
         ? `max(${handleSize(width, 'sm')}, ${handleSize(height, 'sm')})`
-        : handleSize(height, 'sm')
-    };
+        : handleSize(height, 'sm')};
   }
 
   @media screen and (width > ${CONTAINER_SIZE['sm']}) {
-    width: ${
-      props.circle
+    width: ${({ circle, width = 10, height = 1 }) =>
+      circle
         ? `max(${handleSize(width, 'md')}, ${handleSize(height, 'md')})`
-        : handleSize(width, 'md')
-    };
-    height: ${
-      props.circle
+        : handleSize(width, 'md')};
+    height: ${({ circle, width = 10, height = 1 }) =>
+      circle
         ? `max(${handleSize(width, 'md')}, ${handleSize(height, 'md')})`
-        : handleSize(height, 'md')
-    };
+        : handleSize(height, 'md')};
   }
 
   @media screen and (width > ${CONTAINER_SIZE['md']}) {
-    width: ${
-      props.circle
+    width: ${({ circle, width = 10, height = 1 }) =>
+      circle
         ? `max(${handleSize(width, 'lg')}, ${handleSize(height, 'lg')})`
-        : handleSize(width, 'lg')
-    };
-    height: ${
-      props.circle
+        : handleSize(width, 'lg')};
+    height: ${({ circle, width = 10, height = 1 }) =>
+      circle
         ? `max(${handleSize(width, 'lg')}, ${handleSize(height, 'lg')})`
-        : handleSize(height, 'lg')
-    };
+        : handleSize(height, 'lg')};
   }
 
   @media screen and (width > ${CONTAINER_SIZE['lg']}) {
-    width: ${
-      props.circle
+    width: ${({ circle, width = 10, height = 1 }) =>
+      circle
         ? `max(${handleSize(width, 'xl')}, ${handleSize(height, 'xl')})`
-        : handleSize(width, 'xl')
-    };
-    height: ${
-      props.circle
+        : handleSize(width, 'xl')};
+    height: ${({ circle, width = 10, height = 1 }) =>
+      circle
         ? `max(${handleSize(width, 'xl')}, ${handleSize(height, 'xl')})`
-        : handleSize(height, 'xl')
-    };
+        : handleSize(height, 'xl')};
   }
-`
-);
+`;
 
 export default Skeleton;

--- a/src/components/common/Tabs/TabBody.tsx
+++ b/src/components/common/Tabs/TabBody.tsx
@@ -1,5 +1,5 @@
 import { useContext, ReactNode } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import Container from '~/components/common/Container';
 import { TabsValueContext } from './TabsProvider';
 
@@ -18,7 +18,7 @@ const TabBody = ({ id, children }: TabBodyPropsType) => {
         /* stylelint-disable-next-line value-keyword-case */
         boxSizing: 'border-box',
       }}
-      color='var(--adaptive950)'
+      color='--adaptive950'
       className={selectedId === id ? 'mounted' : undefined}
     >
       {children}

--- a/src/components/common/Tabs/TabItem.tsx
+++ b/src/components/common/Tabs/TabItem.tsx
@@ -1,5 +1,5 @@
 import { useContext, ReactNode } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import {
   TabsActionContext,
   TabsStyleContext,

--- a/src/components/common/Text.tsx
+++ b/src/components/common/Text.tsx
@@ -16,17 +16,15 @@ export interface TextPropsType extends CommonStylePropsType {
   inline?: boolean;
 }
 
-const Text = styled.p(
-  (props: TextPropsType) => `
+const Text = styled.p<TextPropsType>`
   ${CommonStyle}
 
-  display: ${props.inline ? 'inline' : undefined};
+  display: ${({ inline }) => (inline ? 'inline' : undefined)};
 
-  color: ${`var(${props.color ?? '--adaptive950'})`};
-  font-weight: ${props.weight ?? '400'};
-  font-size: ${FONT_SIZE[props.size ?? 'md']};
-  line-height: ${LINE_HEIGHT[props.lineHeight ?? 100]};
-`
-);
+  color: ${({ color }) => `var(${color ?? '--adaptive950'})`};
+  font-weight: ${({ weight }) => weight ?? '400'};
+  font-size: ${({ size }) => FONT_SIZE[size ?? 'md']};
+  line-height: ${({ lineHeight }) => LINE_HEIGHT[lineHeight ?? 100]};
+`;
 
 export default Text;

--- a/src/components/feed/FeedListItem.tsx
+++ b/src/components/feed/FeedListItem.tsx
@@ -3,7 +3,7 @@ import Flex from '~/components/common/Flex';
 import Text from '~/components/common/Text';
 import Image from '~/components/common/Image';
 import Avatar from '~/components/common/Avatar';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import FeedFooterItem from './FeedFooterItem';
 
 export interface FeedListItemPropsType {

--- a/src/components/loading/CircleLoading.tsx
+++ b/src/components/loading/CircleLoading.tsx
@@ -1,6 +1,7 @@
 import Container from '../common/Container';
 import ColorType from '~/types/design/color';
-import styled, { keyframes } from 'styled-components';
+import styled from '@emotion/styled';
+import { keyframes } from '@emotion/react';
 
 interface CircleLoadingPropsType {
   size?: number;

--- a/src/components/templates/ProfileSkeleton.tsx
+++ b/src/components/templates/ProfileSkeleton.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import Container from '../common/Container';
 import Text from '../common/Text';
 import Flex from '../common/Flex';

--- a/src/components/templates/ProfileTemplate.tsx
+++ b/src/components/templates/ProfileTemplate.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import {
   IconMessage,
   IconUserMinus,
@@ -68,7 +68,6 @@ const ProfileTemplate = ({ user, auth, actions }: ProfileTemplatePropsType) => {
     if (isMe) {
       setIsShowUpload(true);
     } else {
-      // alert('large profile image');
       setIsShowProfile(true);
     }
   };
@@ -197,18 +196,18 @@ const ProfileTemplate = ({ user, auth, actions }: ProfileTemplatePropsType) => {
             <Text
               size='2xl'
               weight={800}
-              height={175}
+              lineHeight={175}
             >
               {user.fullName}
             </Text>
             <Text
-              height={150}
+              lineHeight={150}
               weight={600}
             >
               {user.email}
             </Text>
             <Text
-              height={150}
+              lineHeight={150}
               weight={600}
             >
               {user.role}

--- a/src/components/uploadImage/ProfileImageUpload.tsx
+++ b/src/components/uploadImage/ProfileImageUpload.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useMemo, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import axios from 'axios';
 import Flex from '~/components/common/Flex';
 import Image from '~/components/common/Image';
@@ -34,7 +34,7 @@ const ProfileImageUpload = ({
     });
     return file;
   }, []);
-  
+
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files && e.target.files[0];
 
@@ -68,7 +68,7 @@ const ProfileImageUpload = ({
   };
 
   return (
-<Flex
+    <Flex
       p={2}
       direction='column'
       gap={2}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -12,7 +12,6 @@ import useUploadPhoto from '~/hooks/api/users/useUploadPhoto';
 const ProfilePage = () => {
   const { userId } = useParams();
 
-
   const {
     status: userStatus,
     data: userData,
@@ -35,7 +34,7 @@ const ProfilePage = () => {
     // eslint-disable-next-line
   }, [userId]);
 
-  if (userStatus === 'success' && userData)
+  if (userStatus === 'success' && userData) {
     return (
       <ProfileTemplate
         user={userData}
@@ -43,8 +42,11 @@ const ProfilePage = () => {
         actions={{ requestUser, createFollow, deleteFollow, uploadPhoto }}
       />
     );
-  else if (userStatus === 'error') return <Text>Error</Text>;
-  else return <ProfileSkeleton />;
+  } else if (userStatus === 'error') {
+    return <Text>Error</Text>;
+  } else {
+    return <ProfileSkeleton />;
+  }
 };
 
 export default ProfilePage;

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -3,7 +3,7 @@ import Modal from '~/components/common/Modal';
 import Flex from '~/components/common/Flex';
 import Text from '~/components/common/Text';
 import Button from '~/components/common/Button';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 
 export default {
   title: 'Component/Modal',

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -1,5 +1,5 @@
 import { IconUser } from '@tabler/icons-react';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import Tabs, { TabsPropsType } from '~/components/common/Tabs';
 import { FONT_SIZE_UNIT, FONT_WEIGHT_UNIT } from '~/constants/design';
 


### PR DESCRIPTION
## :rocket: 주요 작업 내용
- 잘못 마이그레이션된 emotion 공통 로직 수정
- 기존 컴포넌트 emotion으로 마이그레이션
- styled-components 사용 경고 규칙 추가

## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86952779/e2c9a677-6617-443c-93e0-6d4c2ba628cc)

## :white_check_mark: 고민 중인 부분 및 참고사항
- [x] styled-components 사용 경고 규칙을 추가하였습니다.
충돌을 막기 위해 사용 금지를 강제하진 않지만 최대한 emotion을 사용해주세요. 🙇‍♂️

close #107 
