### PR TITLE
[102] 로그인 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,24 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { Outlet } from 'react-router-dom';
+
+import NavBar from './components/common/NavBar';
+
+import { loginState, userState } from './recoil/login/atoms';
+
+function App() {
+  const [isLoggedin, onLogout] = useRecoilState(loginState);
+  const user = useRecoilValue(userState);
+
+  return (
+    <>
+      <NavBar
+        isLoggedIn={isLoggedin}
+        userName={user ? user.fullName : ''}
+        onLogout={() => onLogout(false)}
+      />
+      <Outlet />
+    </>
+  );
+}
+
+export default App;

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import Container from '~/components/common/Container';
-import Text from '~/components/common/Text';
 import Flex from '~/components/common/Flex';
+import Text from '~/components/common/Text';
 import ColorType from '~/types/design/color';
 import { FontSizeType } from '~/types/design/font';
 import { FONT_SIZE } from '~/constants/design';
@@ -73,15 +72,10 @@ const Input = ({
   placeholder,
   message,
   messageColor,
-  isValidate,
   onChange,
   children,
   InputName,
-  inputText,
 }: InputPropsType) => {
-  const [isError, setIsError] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const labelFontSize = 'sm' as FontSizeType;
   const inputFontSize = 'lg' as FontSizeType;
   const messageFontSize = 'sm' as FontSizeType;
@@ -93,37 +87,9 @@ const Input = ({
     const { name, value } = e.target;
 
     if (onChange !== undefined) {
-      debouncing(onChange, value, name);
+      onChange(value, name);
     }
   };
-
-  const debouncing = (
-    callback:
-      | ((text: string, InputName: string) => void)
-      | ((text: string) => void),
-    value: string,
-    name: string
-  ) => {
-    if (timer.current) {
-      clearTimeout(timer.current);
-    }
-    timer.current = setTimeout(() => callback(value, name), 500);
-  };
-
-  useEffect(() => {
-    if (!inputText) {
-      setIsError(false);
-      return;
-    }
-
-    if (isValidate === undefined) {
-      return;
-    }
-
-    const isAvailable = isValidate(inputText);
-
-    setIsError(!isAvailable);
-  }, [inputText, isValidate]);
 
   return (
     <Container
@@ -131,7 +97,7 @@ const Input = ({
       style={{ padding: 0 }}
     >
       <Flex direction='column'>
-        <Border isError={isError}>
+        <Border isError={!!message}>
           <Flex
             direction='column'
             gap={0.25}
@@ -176,7 +142,7 @@ const Input = ({
               width: 'fit-content',
             }}
           >
-            {isError ? (
+            {message ? (
               <Text
                 size={messageFontSize}
                 color={messageColor}

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,9 +1,12 @@
 import styled from '@emotion/styled';
+
 import Container from '~/components/common/Container';
 import Flex from '~/components/common/Flex';
 import Text from '~/components/common/Text';
+
 import ColorType from '~/types/design/color';
 import { FontSizeType } from '~/types/design/font';
+
 import { FONT_SIZE } from '~/constants/design';
 
 export interface InputPropsType {

--- a/src/components/loginForm/LoginForm.tsx
+++ b/src/components/loginForm/LoginForm.tsx
@@ -74,7 +74,6 @@ const LoginForm = ({
             onChange={onChange}
             InputName='email'
           />
-          {!emailErrorMessage() && <Box style={{ height: '0.875rem' }}></Box>}
         </Box>
         <Box>
           <Input
@@ -88,9 +87,6 @@ const LoginForm = ({
             }
             type='password'
           />
-          {!userLoginInfoIsError.password && (
-            <Box style={{ height: '0.875rem' }}></Box>
-          )}
         </Box>
         {children}
         <Container maxWidth='sm'>

--- a/src/components/loginForm/LoginForm.tsx
+++ b/src/components/loginForm/LoginForm.tsx
@@ -9,12 +9,14 @@ import Input from '../input/Input';
 
 import { testRegex } from '~/utils/regex';
 
+import ResponseStatusType from '~/types/api/status';
+
 import { INPUT } from '~/constants/regex';
 
 interface LoginFormProps {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   onChange: (text: string, InputName: string) => void;
-  status: 'stale' | 'loading' | 'error' | 'success';
+  status: ResponseStatusType;
   error: string | null;
   children: React.ReactNode;
   userLoginInfo: {

--- a/src/components/loginForm/LoginForm.tsx
+++ b/src/components/loginForm/LoginForm.tsx
@@ -1,96 +1,124 @@
-import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import Box from '../common/Box';
 import Button from '../common/Button';
 import Container from '../common/Container';
+import CircleLoading from '../loading/CircleLoading';
 import Flex from '../common/Flex';
 import Input from '../input/Input';
-import Text from '../common/Text';
+
 import { testRegex } from '~/utils/regex';
+
 import { INPUT } from '~/constants/regex';
 
-const LoginForm = () => {
-  const [userLoginInfo, setUserLoginInfo] = useState({
-    email: '',
-    password: '',
-  });
-
-  const onChange = (text: string, InputName: string) => {
-    setUserLoginInfo({ ...userLoginInfo, [InputName]: text });
+interface LoginFormProps {
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onChange: (text: string, InputName: string) => void;
+  status: 'stale' | 'loading' | 'error' | 'success';
+  error: string | null;
+  children: React.ReactNode;
+  userLoginInfo: {
+    [key: string]: string;
   };
-
-  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    alert('onSubmit');
+  userLoginInfoIsError: {
+    [key: string]: boolean;
   };
+}
+
+const LoginForm = ({
+  onSubmit,
+  onChange,
+  status,
+  userLoginInfo,
+  userLoginInfoIsError,
+  children,
+}: LoginFormProps) => {
+  const navigate = useNavigate();
 
   const onClick = () => {
-    alert('onClick');
+    navigate('/signup');
+  };
+
+  const isValidate = (text: string, inputName: 'email') => {
+    const inputValue = userLoginInfo[inputName];
+
+    if (!inputValue) return '';
+    return validateInput(inputValue) ? '' : text;
   };
 
   const validateInput = (text: string) => {
     return testRegex(text, INPUT.EMAIL);
   };
 
+  const emailErrorMessage = () => {
+    return userLoginInfoIsError.email
+      ? '이메일을 입력해주세요'
+      : isValidate('올바르지 않은 이메일 형식이에요', 'email');
+  };
+
   return (
-    <Container maxWidth='md'>
-      <form onSubmit={onSubmit}>
-        <Flex direction='column'>
-          <Container maxWidth='sm'>
-            <Text
-              size='lg'
-              color='--adaptive900'
-            >
-              로그인
-            </Text>
-          </Container>
+    <form onSubmit={onSubmit}>
+      <Flex
+        direction='column'
+        gap={1}
+      >
+        <Box>
           <Input
             label='이메일'
-            type='email'
+            type='text'
             placeholder='example@gmail.com'
-            message='올바르지 않은 이메일 형식이에요'
+            message={emailErrorMessage()}
             messageColor='--red600'
             onChange={onChange}
-            isValidate={(text) => validateInput(text)}
             InputName='email'
-            inputText={userLoginInfo.email}
           />
+          {!emailErrorMessage() && <Box style={{ height: '0.875rem' }}></Box>}
+        </Box>
+        <Box>
           <Input
             label='비밀번호'
             placeholder='비밀번호를 입력해주세요'
             onChange={onChange}
             InputName='password'
+            messageColor='--red600'
+            message={
+              userLoginInfoIsError.password ? '비밀번호를 입력해 주세요' : ''
+            }
             type='password'
-            inputText={userLoginInfo.password}
           />
-          <Container
-            maxWidth='md'
-            style={{ width: 'fit-content' }}
+          {!userLoginInfoIsError.password && (
+            <Box style={{ height: '0.875rem' }}></Box>
+          )}
+        </Box>
+        {children}
+        <Container maxWidth='sm'>
+          <Flex
+            direction='column'
+            gap={1}
           >
-            <Flex
-              direction='column'
-              gap={1}
+            <Button
+              size='lg'
+              variant='filled'
+              color='--primaryColor'
+              type='submit'
+              style={{ height: '3rem' }}
             >
-              <Button
-                size='lg'
-                variant='filled'
-                color='--primaryColor'
-                type='submit'
-              >
-                로그인
-              </Button>
-              <Button
-                size='lg'
-                variant='outlined'
-                color='--primaryColor'
-                type='button'
-                onClick={onClick}
-              >
-                가입하기
-              </Button>
-            </Flex>
-          </Container>
-        </Flex>
-      </form>
-    </Container>
+              {status === 'loading' ? <CircleLoading size={1} /> : '로그인'}
+            </Button>
+            <Button
+              size='lg'
+              variant='outlined'
+              color='--primaryColor'
+              type='button'
+              style={{ height: '3rem' }}
+              onClick={onClick}
+            >
+              가입하기
+            </Button>
+          </Flex>
+        </Container>
+      </Flex>
+    </form>
   );
 };
 

--- a/src/components/loginForm/LoginForm.tsx
+++ b/src/components/loginForm/LoginForm.tsx
@@ -1,11 +1,11 @@
 import { useNavigate } from 'react-router-dom';
 
-import Box from '../common/Box';
-import Button from '../common/Button';
-import Container from '../common/Container';
-import CircleLoading from '../loading/CircleLoading';
-import Flex from '../common/Flex';
-import Input from '../input/Input';
+import Box from '~/components/common/Box';
+import Button from '~/components/common/Button';
+import Container from '~/components/common/Container';
+import CircleLoading from '~/components/loading/CircleLoading';
+import Flex from '~/components/common/Flex';
+import Input from '~/components/input/Input';
 
 import { testRegex } from '~/utils/regex';
 

--- a/src/components/templates/LoginTemplate.tsx
+++ b/src/components/templates/LoginTemplate.tsx
@@ -1,0 +1,75 @@
+import Box from '../common/Box';
+import Container from '../common/Container';
+import Flex from '../common/Flex';
+import Text from '../common/Text';
+import LoginForm from '../loginForm/LoginForm';
+
+interface LoginTemplateProps {
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  onChange: (text: string, InputName: string) => void;
+  status: 'stale' | 'loading' | 'error' | 'success';
+  error: string | null;
+  userLoginInfo: {
+    [key: string]: string;
+  };
+  formErrorMessage: string;
+  userLoginInfoIsError: {
+    [key: string]: boolean;
+  };
+}
+
+const LoginTemplate = ({
+  onSubmit,
+  onChange,
+  status,
+  error,
+  userLoginInfo,
+  formErrorMessage,
+  userLoginInfoIsError,
+}: LoginTemplateProps) => {
+  return (
+    <Container maxWidth='md'>
+      <Box style={{ padding: '4rem 0' }}>
+        <Flex
+          direction='column'
+          gap={1}
+        >
+          <Container maxWidth='sm'>
+            <Text
+              size='2xl'
+              color='--adaptive900'
+            >
+              로그인
+            </Text>
+          </Container>
+          <LoginForm
+            onSubmit={onSubmit}
+            onChange={onChange}
+            status={status}
+            error={error}
+            userLoginInfo={userLoginInfo}
+            userLoginInfoIsError={userLoginInfoIsError}
+          >
+            <Box
+              width='sm'
+              style={{ width: '40rem', margin: 'auto' }}
+            >
+              {formErrorMessage ? (
+                <Text
+                  color='--red600'
+                  style={{ paddingLeft: '0.75rem' }}
+                >
+                  {formErrorMessage}
+                </Text>
+              ) : (
+                <Box style={{ height: '1rem' }} />
+              )}
+            </Box>
+          </LoginForm>
+        </Flex>
+      </Box>
+    </Container>
+  );
+};
+
+export default LoginTemplate;

--- a/src/components/templates/LoginTemplate.tsx
+++ b/src/components/templates/LoginTemplate.tsx
@@ -4,10 +4,12 @@ import Flex from '../common/Flex';
 import Text from '../common/Text';
 import LoginForm from '../loginForm/LoginForm';
 
+import ResponseStatusType from '~/types/api/status';
+
 interface LoginTemplateProps {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   onChange: (text: string, InputName: string) => void;
-  status: 'stale' | 'loading' | 'error' | 'success';
+  status: ResponseStatusType;
   error: string | null;
   userLoginInfo: {
     [key: string]: string;

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useRequestFn } from '~/hooks/api';
 import { AUTH } from '~/constants/message';
 import { LoginRequestType, LoginResponseType } from '~/types/api/auth';
@@ -20,13 +21,18 @@ const useLogin = () => {
       }
 
       await request({ data: loginRequest });
-      if (status === 'success' && data.token) {
-        setItem('accessToken', data.token);
-      }
     } catch (e) {
       handleError(e, 'api/auth/login');
     }
   };
+
+  useEffect(() => {
+    if (status === 'success' && data.token) {
+      setItem('accessToken', data.token);
+      return;
+    }
+    setItem('accessToken', '');
+  }, [status, data]);
 
   return { handleLogin, status, error };
 };

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -1,11 +1,18 @@
 import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
 import { useRequestFn } from '~/hooks/api';
-import { AUTH } from '~/constants/message';
-import { LoginRequestType, LoginResponseType } from '~/types/api/auth';
+
+import { loginState } from '~/recoil/login/atoms';
+import { userState } from '~/recoil/login/atoms';
+
 import { setItem } from '~/utils/localStorage';
 import { handleError } from '~/utils/handleError';
 
 const useLogin = () => {
+  const setLoginState = useSetRecoilState(loginState);
+  const setUserState = useSetRecoilState(userState);
+
   const { request, status, data, error } = useRequestFn<LoginResponseType>({
     method: 'post',
     url: '/login',
@@ -29,10 +36,14 @@ const useLogin = () => {
   useEffect(() => {
     if (status === 'success' && data.token) {
       setItem('accessToken', data.token);
+      setUserState(data.user);
+      setLoginState(true);
       return;
     }
     setItem('accessToken', '');
-  }, [status, data]);
+    setUserState({} as UserType);
+    setLoginState(false);
+  }, [status, data, setUserState, setLoginState]);
 
   return { handleLogin, status, error };
 };

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -9,6 +9,11 @@ import { userState } from '~/recoil/login/atoms';
 import { setItem } from '~/utils/localStorage';
 import { handleError } from '~/utils/handleError';
 
+import { LoginRequestType, LoginResponseType } from '~/types/api/auth';
+import { UserType } from '~/types/common';
+
+import { AUTH } from '~/constants/message';
+
 const useLogin = () => {
   const setLoginState = useSetRecoilState(loginState);
   const setUserState = useSetRecoilState(userState);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,10 +1,92 @@
-import Text from '~/components/common/Text';
+import { useEffect, useRef, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
+
+import LoginTemplate from '~/components/templates/LoginTemplate';
+
+import useLogin from '~/hooks/api/auth/useLogin';
+
+import loginState from '~/recoil/login/atoms';
 
 const LoginPage = () => {
+  const setLoginState = useSetRecoilState(loginState);
+  const navigate = useNavigate();
+
+  const [userLoginInfo, setUserLoginInfo] = useState({
+    email: '',
+    password: '',
+  });
+  const [userLoginInfoIsError, setUserLoginInfoIsError] = useState({
+    email: false,
+    password: false,
+  });
+  const [formErrorMessage, setFormErrorMessage] = useState('');
+  const beforeState = useRef({
+    email: '',
+    password: '',
+  });
+
+  const { handleLogin, status, error } = useLogin();
+
+  const onChange = (text: string, InputName: string) => {
+    setUserLoginInfo({ ...userLoginInfo, [InputName]: text });
+    setFormErrorMessage('');
+    setUserLoginInfoIsError({ ...userLoginInfoIsError, [InputName]: !text });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (isSameInputAsBefore()) return;
+    beforeState.current = { ...userLoginInfo };
+
+    setUserLoginInfoIsError({ email: false, password: false });
+
+    if (!userLoginInfo.email) {
+      setUserLoginInfoIsError((error) => {
+        return { ...error, email: true };
+      });
+    }
+    if (!userLoginInfo.password) {
+      setUserLoginInfoIsError((error) => {
+        return { ...error, password: true };
+      });
+    }
+
+    handleLogin(userLoginInfo);
+  };
+
+  const isSameInputAsBefore = () => {
+    return (
+      beforeState.current.email === userLoginInfo.email &&
+      beforeState.current.password === userLoginInfo.password
+    );
+  };
+
+  useEffect(() => {
+    switch (status) {
+      case 'success':
+        setLoginState(true);
+        navigate('/');
+        break;
+      case 'error':
+        setFormErrorMessage('이메일 또는 비밀번호를 확인해 주세요');
+        break;
+      default:
+        break;
+    }
+  }, [status, navigate, setLoginState]);
+
   return (
-    <>
-      <Text>Login</Text>
-    </>
+    <LoginTemplate
+      onChange={onChange}
+      onSubmit={onSubmit}
+      status={status}
+      error={error}
+      userLoginInfo={userLoginInfo}
+      formErrorMessage={formErrorMessage}
+      userLoginInfoIsError={userLoginInfoIsError}
+    />
   );
 };
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,15 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 
 import LoginTemplate from '~/components/templates/LoginTemplate';
 
 import useLogin from '~/hooks/api/auth/useLogin';
 
-import loginState from '~/recoil/login/atoms';
-
 const LoginPage = () => {
-  const setLoginState = useSetRecoilState(loginState);
   const navigate = useNavigate();
 
   const [userLoginInfo, setUserLoginInfo] = useState({
@@ -66,7 +62,6 @@ const LoginPage = () => {
   useEffect(() => {
     switch (status) {
       case 'success':
-        setLoginState(true);
         navigate('/');
         break;
       case 'error':
@@ -75,7 +70,7 @@ const LoginPage = () => {
       default:
         break;
     }
-  }, [status, navigate, setLoginState]);
+  }, [status, navigate]);
 
   return (
     <LoginTemplate

--- a/src/recoil/login/atoms.ts
+++ b/src/recoil/login/atoms.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const loginState = atom({
+  key: 'loginState',
+  default: false,
+});
+
+export default loginState;

--- a/src/recoil/login/atoms.ts
+++ b/src/recoil/login/atoms.ts
@@ -1,8 +1,13 @@
 import { atom } from 'recoil';
 
-const loginState = atom({
+import { UserType } from '~/types/common';
+
+export const loginState = atom({
   key: 'loginState',
   default: false,
 });
 
-export default loginState;
+export const userState = atom<UserType | null>({
+  key: 'userState',
+  default: null,
+});

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,37 +6,58 @@ import ProfilePage from './pages/ProfilePage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import SearchPage from './pages/SearchPage';
+import App from './App';
 
 const router = createBrowserRouter([
   {
-    path: '/',
-    element: <FeedPage />,
-    errorElement: <ErrorPage />,
-  },
-  {
-    path: 'login',
-    element: <LoginPage />,
-    errorElement: <ErrorPage />,
-  },
-  {
-    path: 'signup',
-    element: <SignupPage />,
-    errorElement: <ErrorPage />,
-  },
-  {
-    path: 'search/',
-    element: <SearchPage />,
-    errorElement: <ErrorPage />,
-  },
-  {
-    path: 'post/:postId',
-    element: <PostPage />,
-    errorElement: <ErrorPage />,
-  },
-  {
-    path: 'profile/:userId',
-    element: <ProfilePage />,
-    errorElement: <ErrorPage />,
+    element: <App />,
+    children: [
+      {
+        path: '/',
+        element: <FeedPage />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: '/home',
+        element: <FeedPage />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: 'login',
+        element: <LoginPage />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: 'signup',
+        element: <SignupPage />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: 'search/',
+        element: <SearchPage />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: 'post/:postId',
+        element: <PostPage />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: 'profile/:userId',
+        element: <ProfilePage />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: 'group',
+        element: <ProfilePage />,
+        errorElement: <ErrorPage />,
+      },
+      {
+        path: 'chat',
+        element: <ProfilePage />,
+        errorElement: <ErrorPage />,
+      },
+    ],
   },
 ]);
 

--- a/src/types/api/status.ts
+++ b/src/types/api/status.ts
@@ -1,0 +1,3 @@
+export type ResponseStatusType = 'stale' | 'loading' | 'error' | 'success';
+
+export default ResponseStatusType;


### PR DESCRIPTION
## :rocket: 주요 작업 내용
1. 로그인 페이지를 구현했습니다.

## :pushpin: 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86847564/59c5e2f2-7112-45b0-a839-50a92c813ef6)

## :white_check_mark: 고민 중인 부분 및 참고사항
- [x] 최초에 페이지가 렌더링 되었을 때는 input 아래쪽 메시지가 보이지 않습니다.
- [x] input에 입력된 값이 이전과 동일한 값이면서 이전에 api호출에 실패한 경우에는 버튼을 여러번 눌러도 api 호출을 하지 않습니다.
- [x] 의도하지 않은 결과를 수행할 수 있는 가능성이 있어서 input의 디바운스는 삭제했습니다.
- [x] 이메일의 경우 `1. 입력값이 없는 경우` `2. 이메일 형식에 맞지 않는 경우` 메시지가 다르게 나타납니다.
- [ ] 렌더링 최적화는 추후에 작업하도록 하겠습니다.
- [ ] useLogin의 useEffect에서 login 성공 및 실패시 상태를 업데이트 하도록 추가했습니다.
 
<!-- ## 이슈 번호 close -->
close #102 