### PR TITLE
[121] 사용자 목록 리스트 템플릿 구현

### DIFF
--- a/src/components/templates/UserStateListTemplate.tsx
+++ b/src/components/templates/UserStateListTemplate.tsx
@@ -1,0 +1,107 @@
+import styled from '@emotion/styled';
+
+import Container from '~/components/common/Container';
+import Flex from '~/components/common/Flex';
+import UserStateListItem from '~/components/userListItem/UserStateListItem';
+import Text from '~/components/common/Text';
+import CircleLoading from '~/components/loading/CircleLoading';
+
+import { UserType } from '~/types/common';
+
+export interface UserStateListTemplatePropsType {
+  onlineUserList: UserType[];
+  offlineUserList: UserType[];
+  status: 'stale' | 'loading' | 'error' | 'success';
+}
+
+const ContentDiv = styled.div`
+  overflow: auto;
+
+  width: 12rem;
+  height: 35.75rem;
+  padding: 1rem;
+  border: 1px solid var(--primaryColor);
+  box-shadow: 3px 3px 5px var(--primaryColor);
+
+  overflow-x: hidden;
+
+  &::-webkit-scrollbar {
+    width: 0.25rem;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background: var(--primaryColor);
+  }
+
+  &::-webkit-scrollbar-track {
+    background: var(--red100);
+  }
+`;
+
+const UserStateListTemplate = ({
+  onlineUserList,
+  offlineUserList,
+  status,
+}: UserStateListTemplatePropsType) => {
+  return (
+    <Container maxWidth='sm'>
+      <ContentDiv>
+        <Flex
+          direction='column'
+          gap={1}
+        >
+          <Flex
+            direction='column'
+            gap={0.5}
+          >
+            <Text
+              size='sm'
+              style={{ backgroundColor: 'var(--green100)' }}
+            >
+              온라인
+            </Text>
+            <Flex
+              direction='column'
+              gap={0.25}
+            >
+              {status === 'loading' ? (
+                <CircleLoading size={1} />
+              ) : (
+                onlineUserList?.map((user) => (
+                  <UserStateListItem
+                    key={user._id}
+                    fullName={user.fullName}
+                    src={user.image}
+                    isOnline={user.isOnline}
+                  />
+                ))
+              )}
+            </Flex>
+          </Flex>
+          <Flex
+            direction='column'
+            gap={0.5}
+          >
+            <Text
+              size='sm'
+              style={{ backgroundColor: 'var(--red100)' }}
+            >
+              오프라인
+            </Text>
+            {offlineUserList?.map((user) => (
+              <UserStateListItem
+                key={user._id}
+                fullName={user.fullName}
+                src={user.image}
+                isOnline={user.isOnline}
+              />
+            ))}
+          </Flex>
+        </Flex>
+      </ContentDiv>
+    </Container>
+  );
+};
+
+export default UserStateListTemplate;

--- a/src/components/templates/UserStateListTemplate.tsx
+++ b/src/components/templates/UserStateListTemplate.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react';
+
 import styled from '@emotion/styled';
 
 import Container from '~/components/common/Container';
 import Flex from '~/components/common/Flex';
 import UserStateListItem from '~/components/userListItem/UserStateListItem';
 import Text from '~/components/common/Text';
+import Button from '~/components/common/Button';
 import CircleLoading from '~/components/loading/CircleLoading';
 
 import { UserType } from '~/types/common';
@@ -44,6 +47,12 @@ const UserStateListTemplate = ({
   offlineUserList,
   status,
 }: UserStateListTemplatePropsType) => {
+  const [more, setMore] = useState(false);
+
+  const onClick = () => {
+    setMore(!more);
+  };
+
   return (
     <Container maxWidth='sm'>
       <ContentDiv>
@@ -89,14 +98,34 @@ const UserStateListTemplate = ({
             >
               오프라인
             </Text>
-            {offlineUserList?.map((user) => (
-              <UserStateListItem
-                key={user._id}
-                fullName={user.fullName}
-                src={user.image}
-                isOnline={user.isOnline}
-              />
-            ))}
+            <Button
+              variant={'text'}
+              size={'sm'}
+              onClick={onClick}
+              color={'--adaptive400'}
+              style={{ padding: 0 }}
+            >
+              {!more ? '더보기' : '닫기'}
+            </Button>
+            {more && (
+              <Flex
+                direction='column'
+                gap={0.25}
+              >
+                {status === 'loading' ? (
+                  <CircleLoading size={1} />
+                ) : (
+                  offlineUserList?.map((user) => (
+                    <UserStateListItem
+                      key={user._id}
+                      fullName={user.fullName}
+                      src={user.image}
+                      isOnline={user.isOnline}
+                    />
+                  ))
+                )}
+              </Flex>
+            )}
           </Flex>
         </Flex>
       </ContentDiv>

--- a/src/components/userListItem/UserStateListItem.tsx
+++ b/src/components/userListItem/UserStateListItem.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-import Container from '../common/Container';
-import Image from '../common/Image';
-import Text from '../common/Text';
-import Flex from '../common/Flex';
+import Container from '~/components/common/Container';
+import Image from '~/components/common/Image';
+import Text from '~/components/common/Text';
+import Flex from '~/components/common/Flex';
 
 import ColorType from '~/types/design/color';
 

--- a/src/components/userListItem/UserStateListItem.tsx
+++ b/src/components/userListItem/UserStateListItem.tsx
@@ -1,0 +1,94 @@
+import styled from '@emotion/styled';
+
+import Container from '../common/Container';
+import Image from '../common/Image';
+import Text from '../common/Text';
+import Flex from '../common/Flex';
+
+import ColorType from '~/types/design/color';
+
+export interface UserStateListItemPropsType {
+  src: string;
+  fullName: string;
+  isOnline: boolean;
+}
+
+interface BadgePropsType {
+  color: ColorType;
+}
+
+const ImageBadgeDiv = styled.div`
+  position: relative;
+`;
+
+const ProfileImage = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: end;
+  overflow: hidden;
+  position: relative;
+
+  border-radius: 100%;
+`;
+
+const Badge = styled.div<BadgePropsType>`
+  position: absolute;
+  top: 1.75rem;
+  left: 2rem;
+
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 100%;
+
+  background-color: ${({ color }) => `var(${color})`};
+`;
+
+const UserStateListItem = ({
+  src,
+  fullName,
+  isOnline,
+}: UserStateListItemPropsType) => {
+  return (
+    <Container
+      maxWidth='sm'
+      p={0.5}
+      style={{
+        backgroundColor: 'var(--white)',
+        width: '10rem',
+        borderBottom: '1px solid var(--primaryColor) ',
+      }}
+    >
+      <Flex
+        style={{ position: 'relative' }}
+        gap={0.75}
+        alignItems='center'
+      >
+        <ImageBadgeDiv>
+          <ProfileImage>
+            <Image
+              width={2.5}
+              height={2.5}
+              alt={`${fullName} 프로필 사진`}
+              src={src}
+            />
+          </ProfileImage>
+          {isOnline ? (
+            <Badge color={'--green500'} />
+          ) : (
+            <Badge color={'--red700'} />
+          )}
+        </ImageBadgeDiv>
+        <Flex style={{ flex: 1, maxWidth: '108px' }}>
+          <Text
+            size={'sm'}
+            style={{ wordWrap: 'break-word', maxWidth: '100%' }}
+          >
+            {fullName}
+          </Text>
+        </Flex>
+      </Flex>
+    </Container>
+  );
+};
+
+export default UserStateListItem;

--- a/src/hooks/api/users/useGetUsers.ts
+++ b/src/hooks/api/users/useGetUsers.ts
@@ -1,5 +1,8 @@
-import { GetUsersResponseType } from '~/types/api/users';
 import { useRequestFn } from '~/hooks/api';
+
+import { handleError } from '~/utils/handleError';
+
+import { GetUsersResponseType } from '~/types/api/users';
 
 export const useGetUsers = () => {
   const { request, status, data, error } = useRequestFn<GetUsersResponseType>({
@@ -7,7 +10,14 @@ export const useGetUsers = () => {
     url: '/users/get-users',
   });
 
-  return { status, data, request, error };
+  const handleGetUsers = async () => {
+    try {
+      await request();
+    } catch (e) {
+      handleError(e, 'api/get-users');
+    }
+  };
+  return { handleGetUsers, status, data, error };
 };
 
 export default useGetUsers;

--- a/src/pages/UserStateListPage.tsx
+++ b/src/pages/UserStateListPage.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import Container from '~/components/common/Container';
+import UserStateListTemplate from '~/components/templates/UserStateListTemplate';
+
+import useGetUsers from '~/hooks/api/users/useGetUsers';
+
+import { UserType } from '~/types/common';
+
+export interface UserStateListPagePropsType {
+  userList: UserType[];
+}
+
+const UserStateListPage = () => {
+  const [onlineUser, setOnlineUser] = useState<UserType[]>([]);
+  const [offlineUser, setOfflineUser] = useState<UserType[]>([]);
+
+  const { handleGetUsers, status, data } = useGetUsers();
+
+  const divideOnlineOfflineUserList = useCallback(() => {
+    const online = data ? data.filter((user) => user.isOnline) : [];
+    const offline = data ? data.filter((user) => !user.isOnline) : [];
+    setOnlineUser([...online]);
+    setOfflineUser([...offline]);
+  }, [data]);
+
+  useEffect(() => {
+    handleGetUsers();
+  }, []);
+
+  useEffect(() => {
+    if (status === 'success') {
+      divideOnlineOfflineUserList();
+    }
+  }, [status, divideOnlineOfflineUserList]);
+
+  return (
+    <Container maxWidth='sm'>
+      <UserStateListTemplate
+        onlineUserList={onlineUser}
+        offlineUserList={offlineUser}
+        status={status}
+      />
+    </Container>
+  );
+};
+export default UserStateListPage;

--- a/src/stories/UserStateListTemplate.stories.tsx
+++ b/src/stories/UserStateListTemplate.stories.tsx
@@ -1,0 +1,45 @@
+import UserStateListTemplate from '~/components/templates/UserStateListTemplate';
+import { UserType } from '~/types/common';
+
+export default {
+  title: 'Template/UserStateListTemplate',
+  component: UserStateListTemplate,
+};
+
+export const Default = () => {
+  const onlineUser: UserType[] = [];
+  const offlineUser: UserType[] = [];
+  return (
+    <UserStateListTemplate
+      onlineUserList={onlineUser}
+      offlineUserList={offlineUser}
+      status={'success'}
+    />
+  );
+};
+
+export const Standard = () => {
+  const onlineUser: UserType[] = [];
+  const offlineUser: UserType[] = [];
+  return (
+    <UserStateListTemplate
+      onlineUserList={onlineUser}
+      offlineUserList={offlineUser}
+      status={'success'}
+    />
+  );
+};
+
+export const Loading = () => {
+  const onlineUser: UserType[] = [];
+
+  const offlineUser: UserType[] = [];
+
+  return (
+    <UserStateListTemplate
+      onlineUserList={onlineUser}
+      offlineUserList={offlineUser}
+      status={'loading'}
+    />
+  );
+};

--- a/src/stories/components/UserStateListItem.stories.tsx
+++ b/src/stories/components/UserStateListItem.stories.tsx
@@ -1,0 +1,22 @@
+import UserStateListItem, {
+  UserStateListItemPropsType,
+} from '~/components/userListItem/UserStateListItem';
+
+export default {
+  title: 'Component/UserStateListItem',
+  component: UserStateListItem,
+  argTypes: {
+    src: { control: { type: 'text' } },
+    fullName: { control: { type: 'text' } },
+    isOnline: { control: { type: 'boolean' } },
+  },
+  args: {
+    isOnline: false,
+    src: 'https://picsum.photos/200',
+    fullName: 'user-name',
+  },
+};
+
+export const Default = (args: UserStateListItemPropsType) => {
+  return <UserStateListItem {...args} />;
+};


### PR DESCRIPTION
## :rocket: 주요 작업 내용
1. 사용자 목록 리스트 템플릿을 구현했습니다.
2. 사용자 목록 리스트 페이지를 구현했습니다.
3. 사용자 목록 리스트를 호출하는 hook에 handle 함수를 추가했습니다.
4. response data를 online 사용자 offline 사용자로 구분합니다.

## :pushpin: 스크린샷
아래의 스크린샷에서 보이는 데이터는 mock data를 사용했습니다.
1. 첫 화면에서 스크롤바가 없는 경우
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86847564/1718e9a5-07b4-425a-84d8-cc820c118175)
2. 첫 화면에서 스크롤바가 있는 경우
![image](https://github.com/prgrms-fe-devcourse/FEDC5_brewers_hyunju/assets/86847564/351916d4-0e78-4891-9c53-12608f1d8e8c)



## :white_check_mark: 고민 중인 부분 및 참고사항
- 사용자 이미지 오른쪽 하단에 badge로 온라인 오프라인 구분을 했습니다.
- 사용자 이름이 길어지면 줄바꿈됩니다.
- 온라인 사용자와 오프라인 사용자를 블록 단위로 구분합니다.
- 스크롤 색, 스크롤 배경 색, box-shadow 그림자 색을 primaryColor로 적용했습니다.
- `더보기` 버튼을 클릭하면 오프라인 사용자 목록을 확인할 수 있습니다.
- hook을 이용해서 호출합니다.
- [ ] 실시간으로 업데이트 및 반영 사항에 관한 고민이 있습니다.
- [ ] css는 각 내용 및 영역들을 구분하기 쉽도록 일단 단순하게 구현했습니다.
 

<!-- ## 이슈 번호 close -->
