### PR TITLE
[149] 채팅 페이지 프로필 사진 클릭시 프로필 페이지로 이동하는 기능 추가

### DIFF
--- a/src/components/directMessage/DMItem.tsx
+++ b/src/components/directMessage/DMItem.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 
 import Text from '~/components/common/Text';
 import Flex from '~/components/common/Flex';
+import Image from '../common/Image';
+import { Link } from 'react-router-dom';
 
 interface DMItemPropsType {
   userName: string;
@@ -9,14 +11,11 @@ interface DMItemPropsType {
   size?: 'md' | 'lg';
   src?: string;
   seen: boolean;
+  userId: string;
 }
 
 interface ClampTextPropsType {
   size?: string;
-}
-
-interface AvatarPropsType {
-  avatar?: string;
 }
 
 const ClampText = styled(Text)<ClampTextPropsType>`
@@ -55,16 +54,6 @@ const AvatarContainer = styled.div`
   border-radius: 100%;
 `;
 
-const Avatar = styled.img<AvatarPropsType>`
-  width: 3.5rem;
-  height: 3.5rem;
-
-  background-color: var(--adaptive300);
-
-  alt: 'avatar';
-  src: ${(props) => props.avatar};
-`;
-
 const Badge = styled.div`
   top: 1.75rem;
   left: 2rem;
@@ -82,6 +71,7 @@ const DMItem = ({
   message = '',
   size = 'md',
   seen,
+  userId,
 }: DMItemPropsType) => {
   const messageSize = size === 'md' ? 'sm' : 'md';
 
@@ -97,27 +87,42 @@ const DMItem = ({
           gap={1}
         >
           <AvatarContainer>
-            <Avatar src={src} />
+            <Image
+              width={3.5}
+              height={3.5}
+              alt={`${userName}`}
+              src={src}
+            />
           </AvatarContainer>
-          <Flex
-            direction='column'
-            alignItems='flex-start'
-            gap={0.25}
+          <Link
+            to={`/message/${userId}`}
+            style={{
+              flexGrow: 1,
+              textDecoration: 'none',
+            }}
           >
             <Flex
-              alignItems='center'
+              direction='column'
+              alignItems='flex-start'
+              grow={1}
               gap={0.25}
             >
-              <Text size={size}>{userName}</Text>
-              {!seen && <Badge />}
+              <Flex
+                alignItems='center'
+                gap={0.25}
+                grow={1}
+              >
+                <Text size={size}>{userName}</Text>
+                {!seen && <Badge />}
+              </Flex>
+              <ClampText
+                size={messageSize}
+                color='--adaptive400'
+              >
+                {message}
+              </ClampText>
             </Flex>
-            <ClampText
-              size={messageSize}
-              color='--adaptive400'
-            >
-              {message}
-            </ClampText>
-          </Flex>
+          </Link>
         </Flex>
       </TextContainer>
     </Flex>

--- a/src/components/directMessage/DMItem.tsx
+++ b/src/components/directMessage/DMItem.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 
 import Text from '~/components/common/Text';
 import Flex from '~/components/common/Flex';
-import Image from '../common/Image';
-import { Link } from 'react-router-dom';
+import Image from '~/components/common/Image';
 
 interface DMItemPropsType {
   userName: string;

--- a/src/components/directMessage/DMItem.tsx
+++ b/src/components/directMessage/DMItem.tsx
@@ -87,12 +87,14 @@ const DMItem = ({
           gap={1}
         >
           <AvatarContainer>
-            <Image
-              width={3.5}
-              height={3.5}
-              alt={`${userName}`}
-              src={src}
-            />
+            <Link to={`/profile/${userId}`}>
+              <Image
+                width={3.5}
+                height={3.5}
+                alt={`${userName}`}
+                src={src}
+              />
+            </Link>
           </AvatarContainer>
           <Link
             to={`/message/${userId}`}

--- a/src/components/templates/DMListTemplate.tsx
+++ b/src/components/templates/DMListTemplate.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { userState } from '~/recoil/login/atoms';
 
@@ -63,24 +62,16 @@ const DMListTemplate = ({ conversations, status }: DMListTemplatePropsType) => {
           {status === 'loading' && <CircleLoading size={1} />}
           {status === 'success' && conversations.length ? (
             conversations?.map(({ message, sender, receiver, seen }, index) => (
-              <Link
+              <DMItem
                 key={index}
-                to={`/message/${
-                  sender._id === user?._id ? receiver._id : sender._id
-                }`}
-                style={{ textDecoration: 'none' }}
-              >
-                <DMItem
-                  userName={
-                    sender._id === user?._id
-                      ? receiver.fullName
-                      : sender.fullName
-                  }
-                  message={message}
-                  seen={seen}
-                  src={sender._id === user?._id ? receiver.image : sender.image}
-                />
-              </Link>
+                userName={
+                  sender._id === user?._id ? receiver.fullName : sender.fullName
+                }
+                message={message}
+                seen={seen}
+                src={sender._id === user?._id ? receiver.image : sender.image}
+                userId={sender._id === user?._id ? receiver._id : sender._id}
+              />
             ))
           ) : (
             <Flex

--- a/src/components/templates/DMListTemplate.tsx
+++ b/src/components/templates/DMListTemplate.tsx
@@ -1,11 +1,12 @@
 import { useRecoilValue } from 'recoil';
-import { userState } from '~/recoil/login/atoms';
 
 import Container from '~/components/common/Container';
 import CircleLoading from '~/components/loading/CircleLoading';
 import DMItem from '~/components/directMessage/DMItem';
 import Flex from '~/components/common/Flex';
 import Text from '~/components/common/Text';
+
+import { userState } from '~/recoil/login/atoms';
 
 import { ConversationType } from '~/types/common';
 

--- a/src/pages/PresonalMessagePage.tsx
+++ b/src/pages/PresonalMessagePage.tsx
@@ -26,7 +26,7 @@ const PersonalMessagePage = () => {
       handlePersonalMessageList({
         userId,
       });
-    }, 60000);
+    }, 10000);
     return () => {
       clearInterval(timer);
     };


### PR DESCRIPTION
## :rocket: 주요 작업 내용
1. 채팅 페이지 프로필 사진 클릭시 프로필 페이지로 이동하는 기능을 추가했습니다.

## :pushpin: 스크린샷

## :white_check_mark: 고민 중인 부분 및 참고사항
- [ ] 좌측 원형의 프로필 사진을 클릭하면 프로필 페이지로 이동합니다.
- [ ] 우측 글자가 있는 영역을 클릭하면 메시지를 볼 수 있는 페이지로 이동합니다.

<!-- ## 이슈 번호 close -->
close #149 