### PR TITLE
[168] 입력 글자수에 대해 길이를 제한하는 maxLength props및 기능 추가

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -23,8 +23,9 @@ export interface InputPropsType {
     | ((text: string) => void);
   children?: React.ReactNode;
   InputName?: string;
-  inputText?: string;
+  inputText: string;
   disabled?: boolean;
+  maxLength?: number;
 }
 
 interface BorderPropsType {
@@ -71,6 +72,8 @@ const Input = ({
   children,
   InputName,
   disabled,
+  inputText,
+  maxLength = 0,
 }: InputPropsType) => {
   const labelFontSize = 'sm' as FontSizeType;
   const inputFontSize = 'lg' as FontSizeType;
@@ -81,6 +84,10 @@ const Input = ({
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
+
+    if (maxLength && value.length > maxLength) {
+      return;
+    }
 
     if (onChange !== undefined) {
       onChange(value, name);
@@ -126,6 +133,7 @@ const Input = ({
                 inputFontSize={inputFontSize}
                 onChange={handleChange}
                 disabled={disabled}
+                value={inputText}
               />
             </Flex>
           </Flex>

--- a/src/components/signupForm/SignupForm.tsx
+++ b/src/components/signupForm/SignupForm.tsx
@@ -69,6 +69,7 @@ const SignupForm = ({
             <Input
               label='사용자 이름'
               placeholder='프롱이'
+              maxLength={10}
               message={
                 userSignupInfoIsError.fullName
                   ? '사용자 이름을 입력해 주세요'


### PR DESCRIPTION
## :rocket: 주요 작업 내용
1.  입력 글자수에 대해 길이를 제한하는 maxLength props및 기능을 추가했습니다.

## :pushpin: 스크린샷

## :white_check_mark: 고민 중인 부분 및 참고사항

- [ ] 이름의 경우 10글자 이하로 입력받을 수 있습니다.
- [ ] maxLength를 옵셔널로 지정했습니다.

<!-- ## 이슈 번호 close -->
close #168 