### PR TITLE
[173] 프로필 페이지의 메시지 보내기 버튼 활성화

### DIFF
--- a/src/components/templates/ProfileTemplate.tsx
+++ b/src/components/templates/ProfileTemplate.tsx
@@ -102,6 +102,12 @@ const ProfileTemplate = ({ user, actions }: ProfileTemplatePropsType) => {
     setIsShowUpload(false);
   };
 
+  const handleClickMessage = () => {
+    if (auth && user._id !== auth._id) {
+      navigator(`/message/${user._id}`);
+    }
+  };
+
   return (
     <ProfileContainer maxWidth='md'>
       <Profile maxWidth='md'>
@@ -229,7 +235,8 @@ const ProfileTemplate = ({ user, actions }: ProfileTemplatePropsType) => {
                     stroke={2.5}
                   />
                 }
-                disabled
+                onClick={handleClickMessage}
+                disabled={!auth}
               >
                 메시지
               </Button>


### PR DESCRIPTION
## :rocket: 주요 작업 내용
1. 프로필 페이지의 메시지 보내기 버튼을 활성화했습니다.

## :pushpin: 스크린샷

## :white_check_mark: 고민 중인 부분 및 참고사항
- [ ] 로그인한 사용자에게 메시지 보내기 버튼이 활성화 됩니다.

<!-- ## 이슈 번호 close -->
close #173 