### PR TITLE
[225] 채팅 목록 item의 컨테이너 border를 삭제, box-shadow로 수정

### DIFF
--- a/src/components/directMessage/DMItem.tsx
+++ b/src/components/directMessage/DMItem.tsx
@@ -43,7 +43,6 @@ const TextContainer = styled.div`
   height: fit-content;
   margin: 1rem auto;
   padding: 1rem;
-  border: 1px solid var(--secondaryColor);
 `;
 
 const AvatarContainer = styled.div`
@@ -88,11 +87,7 @@ const DMItem = ({
   const messageSize = size === 'md' ? 'sm' : 'md';
 
   return (
-    <Flex
-      direction='row'
-      alignItems='center'
-      gap={0.75}
-    >
+    <MessageContainer>
       <TextContainer>
         <Flex
           alignItems='center'
@@ -142,8 +137,24 @@ const DMItem = ({
           </div>
         </Flex>
       </TextContainer>
-    </Flex>
+    </MessageContainer>
   );
 };
 
 export default DMItem;
+
+const MessageContainer = styled(Flex)`
+  display: flex;
+  flex-direction: column;
+
+  border-radius: 1rem;
+  box-shadow: 0 0 1.5rem var(--adaptiveOpacity100);
+
+  background-color: var(--transparent);
+
+  box-sizing: border-box;
+
+  &:hover {
+    background-color: var(--adaptiveOpacity100);
+  }
+`;

--- a/src/components/templates/DMListTemplate.tsx
+++ b/src/components/templates/DMListTemplate.tsx
@@ -90,7 +90,7 @@ const DMListTemplate = ({ conversations, status }: DMListTemplatePropsType) => {
           </Flex>
           <Flex
             direction='column'
-            gap={0.25}
+            gap={1.25}
           >
             {status === 'loading' && <CircleLoading size={'sm'} />}
             {status === 'success' && conversations.length ? (


### PR DESCRIPTION
## :rocket: 주요 작업 내용
1. 채팅 목록 item의 컨테이너 border를 삭제, box-shadow로 수정했습니다.

## :pushpin: 스크린샷

## :white_check_mark: 고민 중인 부분 및 참고사항

- [ ] hover 추가

<!-- ## 이슈 번호 close -->
close #225