### PR TITLE
[255] 대화창에 새로운 데이터가 들어오면 scroll이 최하단으로 이동

### DIFF
--- a/src/components/PersonalConversation.tsx
+++ b/src/components/PersonalConversation.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useRef, useEffect } from 'react';
 import styled from '@emotion/styled';
 
 import PersonalMessage from './PersonalMessage';
@@ -17,9 +17,24 @@ const PersonalConversation = ({
   userId,
   children,
 }: PersonalConversationPropsType) => {
+  const rootElementRef = useRef<HTMLDivElement>(null);
+  const messagesLengthRef = useRef(0);
+
   const convertTime = (createdAt: string) => {
     return new Date(createdAt).toLocaleTimeString('ko-KR').slice(0, -3);
   };
+
+  useEffect(() => {
+    if (!messages) return;
+    if (messagesLengthRef.current === messages.length) return;
+    messagesLengthRef.current = messages.length;
+
+    if (rootElementRef.current) {
+      rootElementRef.current.scrollTop =
+        rootElementRef.current.scrollHeight -
+        rootElementRef.current.clientHeight;
+    }
+  }, [messages]);
 
   if (children) {
     return (
@@ -42,6 +57,7 @@ const PersonalConversation = ({
       gap={0.25}
       px={1}
       style={{ height: '66vh', overflowY: 'auto' }}
+      ref={rootElementRef}
     >
       {messages
         ? messages.map((message, index) => (


### PR DESCRIPTION
## :rocket: 주요 작업 내용
1. 대화창에 새로운 데이터가 들어오면 scroll이 최하단으로 이동합니다.
2. 
## :pushpin: 스크린샷

## :white_check_mark: 고민 중인 부분 및 참고사항

- [ ] 자동으로 scroll하여 항상 최신 데이터를 확인합니다.

<!-- ## 이슈 번호 close -->
#255 